### PR TITLE
fix : 알림 목록 확인 api 수정 사항 반영(알림 type에 따라 분기)

### DIFF
--- a/app/src/main/java/com/killingpart/killingpoint/data/model/AlarmDeepLink.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/data/model/AlarmDeepLink.kt
@@ -1,0 +1,47 @@
+package com.killingpart.killingpoint.data.model
+
+import android.net.Uri
+
+/**
+ * 알림 [AlarmItem.type] + [AlarmItem.deepLink] 조합으로 이동 가능 여부·대상을 판별한다.
+ * deepLink는 백엔드 API 경로 형식 (예: `/api/diaries/594`, `/api/subscribes/8/fans`).
+ */
+object AlarmDeepLink {
+
+    fun isNavigable(type: String, deepLink: String): Boolean = when (type) {
+        "LIKE_ALARM", "DIARY_ALARM" -> isDiaryDeepLink(deepLink)
+        "SUBSCRIBE_ALARM" -> isSubscribeFansDeepLink(deepLink)
+        else -> false
+    }
+
+    fun isDiaryDeepLink(deepLink: String): Boolean =
+        pathSegments(deepLink).let { segments ->
+            val i = segments.indexOf("diaries")
+            i >= 0 && i < segments.lastIndex && segments[i + 1].toLongOrNull() != null
+        }
+
+    fun isSubscribeFansDeepLink(deepLink: String): Boolean {
+        val segments = pathSegments(deepLink)
+        val subscribeIndex = segments.indexOf("subscribes")
+        return subscribeIndex >= 0 &&
+            subscribeIndex < segments.lastIndex - 1 &&
+            segments.lastOrNull() == "fans" &&
+            segments.getOrNull(subscribeIndex + 1)?.toLongOrNull() != null
+    }
+
+    fun diaryId(deepLink: String): Long? {
+        if (!isDiaryDeepLink(deepLink)) return null
+        val segments = pathSegments(deepLink)
+        val i = segments.indexOf("diaries")
+        return segments.getOrNull(i + 1)?.toLongOrNull()
+    }
+
+    private fun pathSegments(deepLink: String): List<String> {
+        if (deepLink.isBlank()) return emptyList()
+        val uri = Uri.parse(
+            if (deepLink.startsWith("http")) deepLink
+            else "https://local${if (deepLink.startsWith("/")) deepLink else "/$deepLink"}"
+        )
+        return uri.pathSegments.orEmpty()
+    }
+}

--- a/app/src/main/java/com/killingpart/killingpoint/data/model/AlarmModels.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/data/model/AlarmModels.kt
@@ -17,6 +17,7 @@ data class AlarmItem(
     val title: String,
     val content: String,
     val deepLink: String,
+    val type: String,
     val createDate: String? = null
 )
 

--- a/app/src/main/java/com/killingpart/killingpoint/data/model/DiaryDetail.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/data/model/DiaryDetail.kt
@@ -1,0 +1,55 @@
+package com.killingpart.killingpoint.data.model
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * GET /api/diaries/{diaryId} 단건 조회 응답
+ */
+data class DiaryDetail(
+    @SerializedName("diaryId")
+    val diaryId: Long,
+    val artist: String,
+    @SerializedName("musicTitle")
+    val musicTitle: String,
+    @SerializedName("albumImageUrl")
+    val albumImageUrl: String,
+    val content: String,
+    @SerializedName("videoUrl")
+    val videoUrl: String,
+    val scope: Scope,
+    val duration: String,
+    @SerializedName("totalDuration")
+    val totalDuration: String?,
+    val start: String,
+    val end: String,
+    @SerializedName("createDate")
+    val createDate: String,
+    @SerializedName("updateDate")
+    val updateDate: String,
+    val isLiked: Boolean,
+    @SerializedName("isStored")
+    val isStored: Boolean,
+    val likeCount: Int,
+    val userId: Long,
+    val username: String,
+    val tag: String,
+    val profileImageUrl: String
+) {
+    fun toDiary(): Diary = Diary(
+        id = diaryId,
+        artist = artist,
+        musicTitle = musicTitle,
+        albumImageUrl = albumImageUrl,
+        content = content,
+        videoUrl = videoUrl,
+        scope = scope,
+        duration = duration,
+        start = start,
+        end = end,
+        totalDuration = totalDuration?.toIntOrNull(),
+        createDate = createDate,
+        updateDate = updateDate,
+        isLiked = isLiked,
+        likeCount = likeCount
+    )
+}

--- a/app/src/main/java/com/killingpart/killingpoint/data/remote/ApiService.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/data/remote/ApiService.kt
@@ -14,6 +14,7 @@ import com.killingpart.killingpoint.data.model.UpdateProfileImageRequest
 import com.killingpart.killingpoint.data.model.YoutubeVideoRequest
 import com.killingpart.killingpoint.data.model.SubscribeResponse
 import com.killingpart.killingpoint.data.model.FeedResponse
+import com.killingpart.killingpoint.data.model.DiaryDetail
 import com.killingpart.killingpoint.data.model.FeedDiary
 import com.killingpart.killingpoint.data.model.UserStatistics
 import com.killingpart.killingpoint.data.model.LikeResponse
@@ -92,11 +93,12 @@ interface ApiService {
         @Query("size") size: Int
     ): MyDiaries
 
+    /** GET /api/diaries/{diaryId} — 일기 단건 조회 */
     @GET("diaries/{diaryId}")
-    suspend fun getDiary(
+    suspend fun getDiaryDetail(
         @Header("Authorization") accessToken: String,
         @Path("diaryId") diaryId: Long
-    ): FeedDiary
+    ): DiaryDetail
 
     @POST("diaries")
     suspend fun createDiary(

--- a/app/src/main/java/com/killingpart/killingpoint/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/data/repository/AuthRepository.kt
@@ -44,6 +44,8 @@ import com.killingpart.killingpoint.data.model.UserInitSettingsResponse
 import com.killingpart.killingpoint.data.model.AlarmEnabledResponse
 import com.killingpart.killingpoint.data.model.AlarmResponse
 import com.killingpart.killingpoint.data.model.AlarmEnabledRequest
+import com.killingpart.killingpoint.data.model.AlarmDeepLink
+import com.killingpart.killingpoint.data.model.DiaryDetail
 import com.killingpart.killingpoint.data.model.FcmTokenRequest
 
 class AuthRepository(
@@ -950,12 +952,22 @@ class AuthRepository(
         }
     }
 
-    suspend fun getDiaryById(diaryId: Long): Result<FeedDiary> = withContext(Dispatchers.IO) {
+    /** GET /api/diaries/{diaryId} */
+    suspend fun getDiaryDetail(diaryId: Long): Result<DiaryDetail> = withContext(Dispatchers.IO) {
         runCatching {
             val accessToken = getAccessToken()
                 ?: throw IllegalStateException("액세스 토큰이 없습니다")
-            api.getDiary("Bearer $accessToken", diaryId)
+            api.getDiaryDetail("Bearer $accessToken", diaryId)
         }
+    }
+
+    /** 알림 deepLink(`/api/diaries/{id}`) → 단건 조회 */
+    suspend fun getDiaryDetailByAlarmDeepLink(deepLink: String): Result<DiaryDetail> = withContext(Dispatchers.IO) {
+        val diaryId = AlarmDeepLink.diaryId(deepLink)
+            ?: return@withContext Result.failure(
+                IllegalArgumentException("일기 deepLink가 올바르지 않습니다: $deepLink")
+            )
+        getDiaryDetail(diaryId)
     }
 
     suspend fun getAlarms(page: Int = 0, size: Int = 20): Result<AlarmResponse> = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/SocialScreen/AlarmListScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/SocialScreen/AlarmListScreen.kt
@@ -44,7 +44,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
-import com.killingpart.killingpoint.data.model.FeedDiary
+import com.killingpart.killingpoint.data.model.AlarmDeepLink
+import com.killingpart.killingpoint.data.model.DiaryDetail
 import com.killingpart.killingpoint.data.model.Scope
 import com.killingpart.killingpoint.data.repository.AuthRepository
 import com.killingpart.killingpoint.R
@@ -157,26 +158,25 @@ fun AlarmListScreen(navController: NavController) {
                             verticalArrangement = Arrangement.spacedBy(0.dp)
                         ) {
                             itemsIndexed(state.alarms, key = { _, alarm -> alarm.alarmId }) { index, alarm ->
-                                val navTarget = remember(alarm.alarmId, alarm.deepLink) {
-                                    parseAlarmNavTarget(alarm.deepLink)
+                                val isNavigable = remember(alarm.alarmId, alarm.type, alarm.deepLink) {
+                                    AlarmDeepLink.isNavigable(alarm.type, alarm.deepLink)
                                 }
                                 Column(modifier = Modifier.fillMaxWidth()) {
                                     Row(
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .clickable(enabled = navTarget != null && !opening) {
-                                                val target = navTarget ?: return@clickable
+                                            .clickable(enabled = isNavigable && !opening) {
                                                 opening = true
                                                 coroutineScope.launch {
                                                     try {
-                                                        when (target) {
-                                                            is AlarmNavTarget.Diary -> {
-                                                                repo.getDiaryById(target.id).fold(
-                                                                    onSuccess = { feed ->
+                                                        when (alarm.type) {
+                                                            "LIKE_ALARM", "DIARY_ALARM" -> {
+                                                                repo.getDiaryDetailByAlarmDeepLink(alarm.deepLink).fold(
+                                                                    onSuccess = { detail ->
                                                                         val myUserId = repo.getUserIdFromToken()
                                                                         navigateToDiaryDetail(
                                                                             navController,
-                                                                            feed,
+                                                                            detail,
                                                                             myUserId
                                                                         )
                                                                     },
@@ -191,9 +191,10 @@ fun AlarmListScreen(navController: NavController) {
                                                                 )
                                                             }
 
-                                                            is AlarmNavTarget.SocialFriendFans -> {
-                                                                navController.navigate(
-                                                                    "social?tab=friend&friendListTab=fans"
+                                                            "SUBSCRIBE_ALARM" -> {
+                                                                navigateFromSubscribeDeepLink(
+                                                                    navController,
+                                                                    alarm.deepLink
                                                                 )
                                                             }
                                                         }
@@ -241,37 +242,22 @@ fun AlarmListScreen(navController: NavController) {
     }
 }
 
-private sealed interface AlarmNavTarget {
-    data class Diary(val id: Long) : AlarmNavTarget
-    data object SocialFriendFans : AlarmNavTarget
-}
-
-private fun parseAlarmNavTarget(deepLink: String): AlarmNavTarget? {
-    if (parseSubscribesFansDeepLink(deepLink)) return AlarmNavTarget.SocialFriendFans
-    parseDiaryIdFromDeepLink(deepLink)?.let { return AlarmNavTarget.Diary(it) }
-    return null
-}
-
-/** 예: `/api/subscribes/8/fans` */
-private fun parseSubscribesFansDeepLink(deepLink: String): Boolean =
-    deepLink.isNotBlank() && Regex("""subscribes/\d+/fans""").containsMatchIn(deepLink)
-
-private fun parseDiaryIdFromDeepLink(deepLink: String): Long? {
-    if (deepLink.isBlank()) return null
-    val match = Regex("""diaries/(\d+)""").find(deepLink) ?: return null
-    return match.groupValues[1].toLongOrNull()
+/** `/api/subscribes/{userId}/fans` deepLink → 소셜 > 친구 > 팬덤 */
+private fun navigateFromSubscribeDeepLink(navController: NavController, deepLink: String) {
+    if (!AlarmDeepLink.isSubscribeFansDeepLink(deepLink)) return
+    navController.navigate("social?tab=friend&friendListTab=fans")
 }
 
 private fun navigateToDiaryDetail(
     navController: NavController,
-    feed: FeedDiary,
+    detail: DiaryDetail,
     myUserId: Long?
 ) {
-    val diary = feed.toDiary
-    val isOwnDiary = myUserId != null && feed.userId == myUserId
+    val diary = detail.toDiary()
+    val isOwnDiary = myUserId != null && detail.userId == myUserId
     val authorParams =
-        if (!isOwnDiary && feed.username.isNotBlank() && feed.tag.isNotBlank()) {
-            "&authorUsername=${Uri.encode(feed.username)}&authorTag=${Uri.encode(feed.tag)}"
+        if (!isOwnDiary && detail.username.isNotBlank() && detail.tag.isNotBlank()) {
+            "&authorUsername=${Uri.encode(detail.username)}&authorTag=${Uri.encode(detail.tag)}"
         } else {
             ""
         }


### PR DESCRIPTION
# 변경점 👍
- 알림 목록 확인 api 에 '알림 타입' 필드가 추가됨에 따라, 
  - 기존에는 deeplink 경로에 따라 정규식을 활용해 타입별 이동경로 분기를 구현했다면,
  - 현재는 알림 타입 필드에 따라 분기를 구현하는 구조로 변경하였습니다.
  - '킬링파트에 좋아요가 도착했어요' → type : 'LIKE_ALARM'
  - '새로운 구독자가 생겼어요' →type : 'SUBSCRIBE_ALARM'
  - '새로운 킬링파트 등록됐어요' → type : 'DIARY_ALARM'


