### PR TITLE
[QA] 온보드 과정 QA 반영

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
     buildTypes {
         debug {
             // 필요할 때만 true 로 바꾸면 디버그 메뉴가 보입니다.
-            buildConfigField("Boolean", "SHOW_DEV_MENU", "false")
+            buildConfigField("Boolean", "SHOW_DEV_MENU", "true")
         }
         release {
             isMinifyEnabled = false

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/AddMusicScreen/AddMusicScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/AddMusicScreen/AddMusicScreen.kt
@@ -62,41 +62,41 @@ import kotlinx.coroutines.launch
 import androidx.compose.runtime.rememberCoroutineScope
 import java.util.regex.Pattern
 
-/**
- * ISO 8601 duration 형식(예: "PT2M28S")을 초 단위로 변환
- * @param duration ISO 8601 duration 문자열 (예: "PT2M28S", "PT1H2M30S", "PT30S")
- * @return 초 단위로 변환된 값 (예: 148, 3750, 30)
- */
-fun parseDurationToSeconds(duration: String): Int {
-    // PT 제거
-    val durationStr = duration.removePrefix("PT")
-    if (durationStr.isEmpty()) return 0
-    
-    var totalSeconds = 0
-    
-    // 시간(H) 파싱
-    val hourPattern = Pattern.compile("(\\d+)H")
-    val hourMatcher = hourPattern.matcher(durationStr)
-    if (hourMatcher.find()) {
-        totalSeconds += hourMatcher.group(1).toInt() * 3600
-    }
-    
-    // 분(M) 파싱
-    val minutePattern = Pattern.compile("(\\d+)M")
-    val minuteMatcher = minutePattern.matcher(durationStr)
-    if (minuteMatcher.find()) {
-        totalSeconds += minuteMatcher.group(1).toInt() * 60
-    }
-    
-    // 초(S) 파싱
-    val secondPattern = Pattern.compile("(\\d+)S")
-    val secondMatcher = secondPattern.matcher(durationStr)
-    if (secondMatcher.find()) {
-        totalSeconds += secondMatcher.group(1).toInt()
-    }
-    
-    return totalSeconds
-}
+///**
+// * ISO 8601 duration 형식(예: "PT2M28S")을 초 단위로 변환
+// * @param duration ISO 8601 duration 문자열 (예: "PT2M28S", "PT1H2M30S", "PT30S")
+// * @return 초 단위로 변환된 값 (예: 148, 3750, 30)
+// */
+//fun parseDurationToSeconds(duration: String): Int {
+//    // PT 제거
+//    val durationStr = duration.removePrefix("PT")
+//    if (durationStr.isEmpty()) return 0
+//
+//    var totalSeconds = 0
+//
+//    // 시간(H) 파싱
+//    val hourPattern = Pattern.compile("(\\d+)H")
+//    val hourMatcher = hourPattern.matcher(durationStr)
+//    if (hourMatcher.find()) {
+//        totalSeconds += hourMatcher.group(1).toInt() * 3600
+//    }
+//
+//    // 분(M) 파싱
+//    val minutePattern = Pattern.compile("(\\d+)M")
+//    val minuteMatcher = minutePattern.matcher(durationStr)
+//    if (minuteMatcher.find()) {
+//        totalSeconds += minuteMatcher.group(1).toInt() * 60
+//    }
+//
+//    // 초(S) 파싱
+//    val secondPattern = Pattern.compile("(\\d+)S")
+//    val secondMatcher = secondPattern.matcher(durationStr)
+//    if (secondMatcher.find()) {
+//        totalSeconds += secondMatcher.group(1).toInt()
+//    }
+//
+//    return totalSeconds
+//}
 
 @Composable
 fun AddMusicScreen(
@@ -113,11 +113,10 @@ fun AddMusicScreen(
     ) {
         // Center background logo (subtle)
             Image(
-                painter = painterResource(id = R.drawable.killingpart_logo_dark),
+                painter = painterResource(id = R.drawable.killingpart_logo_gray),
                 contentDescription = "앱 배경 로고",
                 modifier = Modifier
                     .align(Alignment.Center)
-                    .offset(y = (-140).dp)
                     .size(280.dp)
             )
 
@@ -136,7 +135,7 @@ fun AddMusicScreen(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 12.dp, vertical = 8.dp),
+                            .padding(horizontal = 12.dp, vertical = 24.dp),
                         horizontalArrangement = Arrangement.End
                     ) {
                         TextButton(onClick = { navController.navigateToMainClearingStack() }) {

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/OnboardingScreen/OnboardingNameScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/OnboardingScreen/OnboardingNameScreen.kt
@@ -120,13 +120,7 @@ fun OnboardingNameScreen(navController: NavController) {
                     )
                 }
                 Spacer(modifier = Modifier.height(24.dp))
-                Text(
-                    text = "예약어(killingpart / admin / support)는 사용할 수 없습니다.",
-                    color = Color(0xFF5C5D60),
-                    fontFamily = PaperlogyFontFamily,
-                    fontSize = 11.sp,
-                    lineHeight = 16.sp
-                )
+
             }
 
             Button(

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/OnboardingScreen/OnboardingTagScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/OnboardingScreen/OnboardingTagScreen.kt
@@ -103,16 +103,7 @@ fun OnboardingTagScreen(
                     fontFamily = PaperlogyFontFamily,
                     fontSize = 12.sp
                 )
-                if (displayName.isNotBlank()) {
-                    Spacer(modifier = Modifier.height(6.dp))
-                    Text(
-                        text = "이름: $displayName",
-                        color = Color(0xFF5C5D60),
-                        fontFamily = PaperlogyFontFamily,
-                        fontSize = 11.sp
-                    )
-                }
-                Spacer(modifier = Modifier.height(20.dp))
+                Spacer(modifier = Modifier.height(10.dp))
                 OutlinedTextField(
                     value = tagInput,
                     onValueChange = {
@@ -152,13 +143,6 @@ fun OnboardingTagScreen(
                     )
                 }
                 Spacer(modifier = Modifier.height(16.dp))
-                Text(
-                    text = "예약어(admin / support)는 사용할 수 없습니다.",
-                    color = Color(0xFF5C5D60),
-                    fontFamily = PaperlogyFontFamily,
-                    fontSize = 11.sp,
-                    lineHeight = 16.sp
-                )
             }
 
             Button(

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/OnboardingScreen/OnboardingTutorialScreens.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/OnboardingScreen/OnboardingTutorialScreens.kt
@@ -160,7 +160,7 @@ fun OnboardingHomePreviewScreen(navController: NavController) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 8.dp)
+                .padding(horizontal = 12.dp, vertical = 24.dp)
         ) {
             IconButton(
                 onClick = { navController.popBackStack() },
@@ -184,7 +184,6 @@ fun OnboardingHomePreviewScreen(navController: NavController) {
                 )
             }
         }
-        Spacer(modifier = Modifier.height(14.dp))
         Text(
             text = "추가한 킬링파트는\n여기서 다시 볼 수 있어요.",
             color = Color.White,
@@ -270,7 +269,7 @@ fun OnboardingFeedDemoScreen(navController: NavController) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 8.dp),
+                .padding(horizontal = 12.dp, vertical = 24.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(


### PR DESCRIPTION
# 변경점 👍
- 온보드 과정 이름 및 태그 입력 과정 정보 노출 최소화 
- 온보드 과정 킬링파트 등록 및 열람 과정에서 '건너뛰기' 텍스트 및 뒤로가기 아이콘 아래로 조정, 배경 킬링파트 로고 중앙화
## 스크린샷
- (화면 우측에 있는 보라색 메뉴들은 디버그 모드에서만 나타나는 항목들 입니다)
<img width="323" height="672" alt="image" src="https://github.com/user-attachments/assets/e2540e1b-83fa-4155-a6ac-997751fa2851" />

<img width="324" height="670" alt="image" src="https://github.com/user-attachments/assets/7127e6e9-8a06-412c-8d80-724ad7b70310" />
