### PR TITLE
qa: 나의 픽  탭 내에서만 엔트리 내 '나의 픽' 표기 삭제

### DIFF
--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/SocialScreen/FriendScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/SocialScreen/FriendScreen.kt
@@ -325,19 +325,13 @@ fun FriendScreen(
                         verticalArrangement = Arrangement.spacedBy(10.dp),
                     ) {
                         items(friends) { user ->
-                            // 검색 결과인 경우와 일반 목록인 경우를 구분
-                            val isSearchResult = state.searchResults != null && searchText.isNotBlank()
+
                             FriendItemCard(
                                 user = user,
                                 navController = navController,
                                 currentUserId = currentUserId,
-                                isPickTab = if (isSearchResult) {
-                                    // 검색 결과에서는 user.isMyPick만 확인
-                                    user.isMyPick
-                                } else {
-                                    // 일반 목록에서는 탭이 PICKS이거나 이미 나의 픽인 경우
-                                    selectedTab == FriendTab.PICKS || user.isMyPick
-                                },
+                                // 현재 선택된 상단 탭 (픽 / 팬덤). user.isMyPick 과 혼동하지 않음
+                                isPickTab = selectedTab == FriendTab.PICKS,
                                 onSubscribeClick = {
 
                                     // friendViewModel.addSubscribe(context, user.userId, currentUserId)
@@ -453,8 +447,8 @@ fun FriendItemCard(
                         fontSize = 12.sp,
                         color = Color.White
                     )
-                    // 나의 픽 표시 (이미 구독한 경우에만)
-                    if ( user.isMyPick ) {
+                    // 팬덤 탭에서만: 나를 팔로우한 사람 중 내가 이미 픽한 경우
+                    if (!isPickTab && user.isMyPick) {
                         Text(
                             text = "나의 픽",
                             fontFamily = PaperlogyFontFamily,


### PR DESCRIPTION
# 변경점 👍
- 소셜 > 친구 > 나의 픽 탭에서는 엔트리 항목 우측의 '나의 픽' 문구를 표시하지 않도록 수정하였습니다
- 검색 결과 및 나의 팬덤 탭에서만 '나의 픽' 문구가 표시되도록 합니다.

## 스크린샷
<img width="336" height="693" alt="image" src="https://github.com/user-attachments/assets/d65bf2f1-089c-4fa6-9df4-0056108af77c" />

