### PR TITLE
chore: 온보딩 과정 amplitude event log

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "amplitude": {
+      "enabled": true
+    }
+  }
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,10 @@ android {
         applicationId = "com.killingpart.killingpoint"
         minSdk = 29
         targetSdk = 36
-        versionCode = 34
-        versionName = "2.2.5"
+        versionCode = 35
+        versionName = "2.2.6"
+
+        buildConfigField("String", "AMPLITUDE_API_KEY", "\"fcb84a98b48f87f85e7112a1587976fd\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -87,4 +89,6 @@ dependencies {
     implementation("com.pierfrancescosoffritti.androidyoutubeplayer:chromecast-sender:0.32")
     implementation("androidx.media3:media3-exoplayer:1.2.1")
     implementation("androidx.media3:media3-ui:1.2.1")
+    implementation("com.amplitude:analytics-android:1.+")
+    implementation("com.amplitude:plugin-session-replay-android:0.20.14")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
+        android:name=".KillingPointApplication"
         android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/killingpart/killingpoint/KillingPointApplication.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/KillingPointApplication.kt
@@ -1,0 +1,26 @@
+package com.killingpart.killingpoint
+
+import android.app.Application
+import com.amplitude.android.Amplitude
+import com.amplitude.android.Configuration
+import com.amplitude.android.plugins.SessionReplayPlugin
+import com.killingpart.killingpoint.analytics.AmplitudeAnalytics
+
+class KillingPointApplication : Application() {
+    lateinit var amplitude: Amplitude
+        private set
+
+    override fun onCreate() {
+        super.onCreate()
+        amplitude = Amplitude(
+            Configuration(
+                apiKey = BuildConfig.AMPLITUDE_API_KEY,
+                context = applicationContext,
+                // 커스텀 이벤트만 수집 (Application Opened, Screen Viewed 등 자동 추적 비활성화)
+                autocapture = emptySet()
+            )
+        )
+        amplitude.add(SessionReplayPlugin())
+        AmplitudeAnalytics.init(applicationContext)
+    }
+}

--- a/app/src/main/java/com/killingpart/killingpoint/MainActivity.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/MainActivity.kt
@@ -30,6 +30,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
 import com.kakao.sdk.common.KakaoSdk
 import com.killingpart.killingpoint.BuildConfig
+import com.killingpart.killingpoint.analytics.AmplitudeAnalytics
+import com.killingpart.killingpoint.analytics.OnboardingAnalytics
 import com.killingpart.killingpoint.data.repository.AuthRepository
 import com.killingpart.killingpoint.navigation.NavGraph
 import com.killingpart.killingpoint.navigation.OnboardingProgressStore
@@ -49,6 +51,8 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         KakaoSdk.init(this, getString(R.string.kakao_native_app_key))
+        AmplitudeAnalytics.init(applicationContext)
+        OnboardingAnalytics.appOpened()
         requestNotificationPermissionIfNeeded()
         enableEdgeToEdge()
         window.statusBarColor = AndroidColor.BLACK
@@ -74,6 +78,10 @@ class MainActivity : ComponentActivity() {
                 mutableStateOf<String?>(null)
             }
 
+            var previousLoginState by remember {
+                mutableStateOf<LoginUiState?>(null)
+            }
+
             LaunchedEffect(Unit) {
                 loginViewModel.tryAutoLogin(context)
             }
@@ -95,6 +103,12 @@ class MainActivity : ComponentActivity() {
             LaunchedEffect(loginState, context) {
                 when (val s = loginState) {
                     is LoginUiState.AutoLoginSuccess -> {
+                        if (previousLoginState !is LoginUiState.AutoLoginSuccess) {
+                            OnboardingAnalytics.authCompleted(
+                                provider = s.provider,
+                                isNewUser = s.isNew
+                            )
+                        }
                         FcmTokenSync.syncCurrentToken(context)
                         val repo = AuthRepository(context)
                         val start = repo.getUserInitSettings()
@@ -123,6 +137,7 @@ class MainActivity : ComponentActivity() {
                         resolvedStartDestination = null
                     }
                 }
+                previousLoginState = loginState
             }
 
             Box(

--- a/app/src/main/java/com/killingpart/killingpoint/analytics/AmplitudeAnalytics.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/analytics/AmplitudeAnalytics.kt
@@ -1,0 +1,23 @@
+package com.killingpart.killingpoint.analytics
+
+import android.content.Context
+import com.killingpart.killingpoint.KillingPointApplication
+
+object AmplitudeAnalytics {
+    private var appContext: Context? = null
+
+    private val amplitude
+        get() = (appContext?.applicationContext as? KillingPointApplication)?.amplitude
+
+    fun init(context: Context) {
+        appContext = context.applicationContext
+    }
+
+    fun track(event: String, properties: Map<String, Any?> = emptyMap()) {
+        if (properties.isEmpty()) {
+            amplitude?.track(event)
+        } else {
+            amplitude?.track(event, properties)
+        }
+    }
+}

--- a/app/src/main/java/com/killingpart/killingpoint/analytics/OnboardingAnalytics.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/analytics/OnboardingAnalytics.kt
@@ -1,0 +1,39 @@
+package com.killingpart.killingpoint.analytics
+
+object OnboardingAnalytics {
+    object SkipStep {
+        const val TUTORIAL_CHOICE = "tutorial_choice"
+        const val TUTORIAL_TRACK_SEARCH = "tutorial_track_search"
+        const val TUTORIAL_TRIM = "tutorial_trim"
+        const val TUTORIAL_HOME = "tutorial_home"
+        const val TUTORIAL_DIARY_DETAIL = "tutorial_diary_detail"
+        const val TUTORIAL_NOTIFICATION = "tutorial_notification"
+        const val UNKNOWN = "unknown"
+    }
+
+    fun appOpened() {
+        AmplitudeAnalytics.track("app_opened")
+    }
+
+    fun authCompleted(provider: String, isNewUser: Boolean) {
+        val event = if (isNewUser) "signup_completed" else "signin_completed"
+        AmplitudeAnalytics.track(
+            event,
+            mapOf(
+                "provider" to provider,
+                "is_new_user" to isNewUser
+            )
+        )
+    }
+
+    fun onboardSkipped(skipStep: String) {
+        AmplitudeAnalytics.track(
+            "onboard_skipped",
+            mapOf("skip_step" to skipStep)
+        )
+    }
+
+    fun onboardCompleted() {
+        AmplitudeAnalytics.track("onboard_completed")
+    }
+}

--- a/app/src/main/java/com/killingpart/killingpoint/navigation/NavGraphExtensions.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/navigation/NavGraphExtensions.kt
@@ -1,12 +1,18 @@
 package com.killingpart.killingpoint.navigation
 
 import androidx.navigation.NavController
+import com.killingpart.killingpoint.analytics.OnboardingAnalytics
 
 /**
  * 온보딩/튜토리얼을 건너뛸 때 메인으로 이동하고 백스택을 정리한다.
  * [MainActivity]의 초기 네비게이션과 동일하게 graph id 0 기준으로 pop 한다.
  */
-fun NavController.navigateToMainClearingStack() {
+fun NavController.navigateToMainClearingStack(skipStep: String) {
+    OnboardingAnalytics.onboardSkipped(skipStep)
+    finishOnboardingAndGoMain()
+}
+
+fun NavController.finishOnboardingAndGoMain() {
     OnboardingProgressStore.clearTutorialInProgress(context)
     navigate("main") {
         popUpTo(0) { inclusive = true }

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/AddMusicScreen/AddMusicScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/AddMusicScreen/AddMusicScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.TextButton
 import androidx.compose.ui.text.font.FontWeight
+import com.killingpart.killingpoint.analytics.OnboardingAnalytics
 import com.killingpart.killingpoint.navigation.navigateToMainClearingStack
 import com.killingpart.killingpoint.ui.theme.PaperlogyFontFamily
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -138,7 +139,9 @@ fun AddMusicScreen(
                             .padding(horizontal = 12.dp, vertical = 24.dp),
                         horizontalArrangement = Arrangement.End
                     ) {
-                        TextButton(onClick = { navController.navigateToMainClearingStack() }) {
+                        TextButton(onClick = {
+                            navController.navigateToMainClearingStack(OnboardingAnalytics.SkipStep.TUTORIAL_TRACK_SEARCH)
+                        }) {
                             Text(
                                 "건너뛰기",
                                 color = Color.White,

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/OnboardingScreen/OnboardingTutorialScreens.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/OnboardingScreen/OnboardingTutorialScreens.kt
@@ -56,6 +56,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import com.killingpart.killingpoint.data.model.Diary
 import com.killingpart.killingpoint.data.repository.AuthRepository
+import com.killingpart.killingpoint.analytics.OnboardingAnalytics
+import com.killingpart.killingpoint.navigation.finishOnboardingAndGoMain
 import com.killingpart.killingpoint.navigation.navigateToMainClearingStack
 import com.killingpart.killingpoint.ui.screen.ArchiveScreen.OuterBox
 import com.killingpart.killingpoint.ui.screen.MainScreen.TopPillTabs
@@ -119,7 +121,7 @@ fun OnboardingKpIntroScreen(navController: NavController) {
                     )
                 }
                 Button(
-                    onClick = { navController.navigateToMainClearingStack() },
+                    onClick = { navController.navigateToMainClearingStack(OnboardingAnalytics.SkipStep.TUTORIAL_CHOICE) },
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(54.dp),
@@ -173,7 +175,7 @@ fun OnboardingHomePreviewScreen(navController: NavController) {
                 )
             }
             TextButton(
-                onClick = { navController.navigateToMainClearingStack() },
+                onClick = { navController.navigateToMainClearingStack(OnboardingAnalytics.SkipStep.TUTORIAL_HOME) },
                 modifier = Modifier.align(Alignment.CenterEnd)
             ) {
                 Text(
@@ -286,7 +288,11 @@ fun OnboardingFeedDemoScreen(navController: NavController) {
                 color = Color.White,
                 fontFamily = PaperlogyFontFamily,
                 textDecoration = TextDecoration.Underline,
-                modifier = Modifier.padding(8.dp)
+                modifier = Modifier
+                    .padding(8.dp)
+                    .clickable {
+                        navController.navigateToMainClearingStack(OnboardingAnalytics.SkipStep.TUTORIAL_NOTIFICATION)
+                    }
             )
         }
         Column(
@@ -627,7 +633,10 @@ fun OnboardingFinishScreen(navController: NavController) {
                 textAlign = TextAlign.Center
             )
             Button(
-                onClick = { navController.navigateToMainClearingStack() },
+                onClick = {
+                    OnboardingAnalytics.onboardCompleted()
+                    navController.finishOnboardingAndGoMain()
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(54.dp),

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/SelectDurationScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/SelectDurationScreen.kt
@@ -54,6 +54,7 @@ import com.killingpart.killingpoint.ui.screen.WriteDiaryScreen.AlbumDiaryBoxWith
 import com.killingpart.killingpoint.data.model.Diary
 import com.killingpart.killingpoint.data.model.Scope
 import com.killingpart.killingpoint.ui.component.BottomBar
+import com.killingpart.killingpoint.analytics.OnboardingAnalytics
 import com.killingpart.killingpoint.navigation.navigateToMainClearingStack
 import androidx.compose.material3.TextButton
 import androidx.compose.ui.graphics.graphicsLayer
@@ -231,7 +232,9 @@ fun SelectDurationScreen(
                 }
                 if (tutorialMode) {
                     TextButton(
-                        onClick = { navController.navigateToMainClearingStack() },
+                        onClick = {
+                            navController.navigateToMainClearingStack(OnboardingAnalytics.SkipStep.TUTORIAL_TRIM)
+                        },
                         modifier = Modifier.align(Alignment.CenterEnd)
                     ) {
                         Text(

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/WriteDiaryScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/WriteDiaryScreen.kt
@@ -44,6 +44,7 @@ import com.killingpart.killingpoint.ui.screen.AddMusicScreen.korean_font_medium
 import com.killingpart.killingpoint.data.model.Diary
 import com.killingpart.killingpoint.data.model.Scope
 import com.killingpart.killingpoint.ui.component.BottomBar
+import com.killingpart.killingpoint.analytics.OnboardingAnalytics
 import com.killingpart.killingpoint.navigation.navigateToMainClearingStack
 import com.killingpart.killingpoint.ui.theme.PaperlogyFontFamily
 import androidx.compose.material3.TextButton
@@ -129,7 +130,9 @@ fun WriteDiaryScreen(
                 }
                 if (tutorialMode) {
                     TextButton(
-                        onClick = { navController.navigateToMainClearingStack() },
+                        onClick = {
+                            navController.navigateToMainClearingStack(OnboardingAnalytics.SkipStep.TUTORIAL_DIARY_DETAIL)
+                        },
                         modifier = Modifier.align(Alignment.CenterEnd)
                     ) {
                         Text(

--- a/app/src/main/java/com/killingpart/killingpoint/ui/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/viewmodel/LoginViewModel.kt
@@ -16,7 +16,7 @@ sealed interface LoginUiState {
     data object Loading : LoginUiState
     data object Success : LoginUiState
     data class Error(val message: String) : LoginUiState
-    data class AutoLoginSuccess(val isNew: Boolean) : LoginUiState // 자동 로그인 성공 (isNew 포함)
+    data class AutoLoginSuccess(val isNew: Boolean, val provider: String) : LoginUiState
 }
 
 class LoginViewModel(
@@ -46,7 +46,7 @@ class LoginViewModel(
         viewModelScope.launch {
             repo.exchangeKakaoAccessToken(kakaoAccessToken)
                 .onSuccess { isNew ->
-                    _state.value = LoginUiState.AutoLoginSuccess(isNew)
+                    _state.value = LoginUiState.AutoLoginSuccess(isNew = isNew, provider = "kakao")
                 }
                 .onFailure { _state.value = LoginUiState.Error(it.message ?: "로그인 실패") }
         }
@@ -58,7 +58,7 @@ class LoginViewModel(
         viewModelScope.launch {
             repo.loginWithTest()
                 .onSuccess { isNew ->
-                    _state.value = LoginUiState.AutoLoginSuccess(isNew)
+                    _state.value = LoginUiState.AutoLoginSuccess(isNew = isNew, provider = "test")
                 }
                 .onFailure { _state.value = LoginUiState.Error(it.message ?: "테스터 로그인 실패") }
         }
@@ -75,7 +75,7 @@ class LoginViewModel(
                 repo.refreshAccessToken()
                     .onSuccess { isNew ->
                         android.util.Log.d("LoginViewModel", "자동 로그인 성공: isNew=$isNew")
-                        _state.value = LoginUiState.AutoLoginSuccess(isNew)
+                        _state.value = LoginUiState.AutoLoginSuccess(isNew = isNew, provider = "session")
                     }
                     .onFailure { e ->
                         android.util.Log.e("LoginViewModel", "자동 로그인 실패: ${e.message}")


### PR DESCRIPTION
# 변경점 👍
- 온보딩 과정의 단계별로 이벤트 로그를 심었습니다.

이벤트명 | 의미 | 발생 시점 | 프로퍼티
-- | -- | -- | --
app_opened | 앱 실행 | 사용자가 앱을 실행했을 때 | 없음
signup_completed | 회원가입 완료 | 신규 사용자가 로그인/가입에 성공했을 때 | provider, is_new_user
signin_completed | 로그인 완료 | 기존 사용자가 로그인에 성공했을 때 | provider, is_new_user
onboard_skipped | 온보딩 스킵 | 사용자가 온보딩 도중 스킵 버튼을 눌렀을 때 | skip_step
onboard_completed | 온보딩 완료 | 사용자가 온보딩 마지막 단계에서 시작하기를 눌렀을 때 | 없음

- skip_step 프로퍼티 종류

값 | 의미
-- | --
tutorial_choice | 튜토리얼 선택 단계
tutorial_track_search | 곡 검색 튜토리얼 단계
tutorial_trim | 구간 편집 튜토리얼 단계
tutorial_home | 홈 화면 튜토리얼 단계
tutorial_diary_detail | 다이어리 상세 튜토리얼 단계
tutorial_notification | 알림 튜토리얼 단계
unknown | 정의되지 않은 단계


<!-- notionvc: 1afd90f1-0c9f-48ea-9136-822153b90e16 -->
