### PR TITLE
킬링파트 구간 자르기 이벤트 로그 추가

### DIFF
--- a/app/src/main/java/com/killingpart/killingpoint/KillingPointApplication.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/KillingPointApplication.kt
@@ -2,6 +2,7 @@ package com.killingpart.killingpoint
 
 import android.app.Application
 import com.amplitude.android.Amplitude
+import com.amplitude.android.AutocaptureOption
 import com.amplitude.android.Configuration
 import com.amplitude.android.plugins.SessionReplayPlugin
 import com.killingpart.killingpoint.analytics.AmplitudeAnalytics
@@ -16,11 +17,10 @@ class KillingPointApplication : Application() {
             Configuration(
                 apiKey = BuildConfig.AMPLITUDE_API_KEY,
                 context = applicationContext,
-                // 커스텀 이벤트만 수집 (Application Opened, Screen Viewed 등 자동 추적 비활성화)
-                autocapture = emptySet()
+                autocapture = setOf(AutocaptureOption.APP_LIFECYCLES)
             )
         )
         amplitude.add(SessionReplayPlugin())
-        AmplitudeAnalytics.init(applicationContext)
+        AmplitudeAnalytics.init(amplitude)
     }
 }

--- a/app/src/main/java/com/killingpart/killingpoint/MainActivity.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/MainActivity.kt
@@ -30,7 +30,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
 import com.kakao.sdk.common.KakaoSdk
 import com.killingpart.killingpoint.BuildConfig
-import com.killingpart.killingpoint.analytics.AmplitudeAnalytics
 import com.killingpart.killingpoint.analytics.OnboardingAnalytics
 import com.killingpart.killingpoint.data.repository.AuthRepository
 import com.killingpart.killingpoint.navigation.NavGraph
@@ -51,7 +50,6 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         KakaoSdk.init(this, getString(R.string.kakao_native_app_key))
-        AmplitudeAnalytics.init(applicationContext)
         OnboardingAnalytics.appOpened()
         requestNotificationPermissionIfNeeded()
         enableEdgeToEdge()

--- a/app/src/main/java/com/killingpart/killingpoint/analytics/AmplitudeAnalytics.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/analytics/AmplitudeAnalytics.kt
@@ -1,16 +1,13 @@
 package com.killingpart.killingpoint.analytics
 
-import android.content.Context
-import com.killingpart.killingpoint.KillingPointApplication
+import com.amplitude.android.Amplitude
+import com.amplitude.android.events.Identify
 
 object AmplitudeAnalytics {
-    private var appContext: Context? = null
+    private var amplitude: Amplitude? = null
 
-    private val amplitude
-        get() = (appContext?.applicationContext as? KillingPointApplication)?.amplitude
-
-    fun init(context: Context) {
-        appContext = context.applicationContext
+    fun init(amplitudeInstance: Amplitude) {
+        amplitude = amplitudeInstance
     }
 
     fun track(event: String, properties: Map<String, Any?> = emptyMap()) {
@@ -19,5 +16,9 @@ object AmplitudeAnalytics {
         } else {
             amplitude?.track(event, properties)
         }
+    }
+
+    fun incrementUserProperty(property: String, by: Double = 1.0) {
+        amplitude?.identify(Identify().add(property, by))
     }
 }

--- a/app/src/main/java/com/killingpart/killingpoint/analytics/KillingPartCutAnalytics.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/analytics/KillingPartCutAnalytics.kt
@@ -1,0 +1,38 @@
+package com.killingpart.killingpoint.analytics
+
+object KillingPartCutAnalytics {
+    object HandleSide {
+        const val LEFT = "left"
+        const val RIGHT = "right"
+        const val SPECTRUM_BAR = "spectrum_bar"
+    }
+
+    fun killingpartCutStarted() {
+        AmplitudeAnalytics.track("killingpart_cut_started")
+    }
+
+    fun trackSelected(songId: String?) {
+        val properties = songId?.let { mapOf("selected_songid" to it) } ?: emptyMap()
+        AmplitudeAnalytics.track("track_selected", properties)
+    }
+
+    fun cutHandleAdjusted(handleSide: String) {
+        AmplitudeAnalytics.track(
+            "cut_handle_adjusted",
+            mapOf("handle_side" to handleSide)
+        )
+    }
+
+    fun cutCompleted() {
+        AmplitudeAnalytics.track("cut_completed")
+    }
+
+    fun killingpartCutCompleted() {
+        AmplitudeAnalytics.track("killingpart_cut_completed")
+        AmplitudeAnalytics.incrementUserProperty("total_killingpart_registered_count")
+    }
+
+    fun onboardingKillingpartCutCompleted() {
+        AmplitudeAnalytics.track("onboarding_killingpart_cut_completed")
+    }
+}

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/AddMusicScreen/AddMusicScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/AddMusicScreen/AddMusicScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.TextButton
 import androidx.compose.ui.text.font.FontWeight
+import com.killingpart.killingpoint.analytics.KillingPartCutAnalytics
 import com.killingpart.killingpoint.analytics.OnboardingAnalytics
 import com.killingpart.killingpoint.navigation.navigateToMainClearingStack
 import com.killingpart.killingpoint.ui.theme.PaperlogyFontFamily
@@ -60,6 +61,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.ui.platform.LocalInspectionMode
 import com.killingpart.killingpoint.data.repository.AuthRepository
 import kotlinx.coroutines.launch
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import java.util.regex.Pattern
 
@@ -106,6 +108,10 @@ fun AddMusicScreen(
 ) {
     var globalLoading by remember { mutableStateOf(false) }
     val bg = if (tutorialMode) Color.Black else Color(0xFF1D1E20)
+
+    LaunchedEffect(Unit) {
+        KillingPartCutAnalytics.killingpartCutStarted()
+    }
     
     Box(
         modifier = Modifier
@@ -246,6 +252,8 @@ private fun TrackRowWithVideoSearch(
 
     TrackRow(track, onClick = {
         if (isLoading) return@TrackRow
+
+        KillingPartCutAnalytics.trackSelected(track.id)
         
         isLoading = true
         onLoadingChange(true)
@@ -321,9 +329,23 @@ private fun TrackRow(track: SimpleTrack, onClick: () -> Unit = {}, isLoading: Bo
             }
             Spacer(modifier = Modifier.width(12.dp))
             Column(modifier = Modifier.fillMaxWidth()) {
-                Text(text = track.title, color = Color.White, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(
+                    text = track.title,
+                    color = Color.White,
+                    fontFamily = PaperlogyFontFamily,
+                    fontSize = 14.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
                 Spacer(modifier = Modifier.height(4.dp))
-                Text(text = track.artist, color = Color(0xFFA4A4A6), maxLines = 1)
+                Text(
+                    text = track.artist,
+                    color = Color(0xFFA4A4A6),
+                    fontFamily = PaperlogyFontFamily,
+                    fontSize = 14.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
         }
     }

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/OnboardingScreen/OnboardingTagScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/OnboardingScreen/OnboardingTagScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.killingpart.killingpoint.data.repository.AuthRepository
 import com.killingpart.killingpoint.navigation.OnboardingProgressStore
+import com.killingpart.killingpoint.ui.screen.ProfileScreen.parseSettingsApiError
 import com.killingpart.killingpoint.ui.theme.PaperlogyFontFamily
 import kotlinx.coroutines.launch
 import org.json.JSONObject
@@ -155,7 +156,19 @@ fun OnboardingTagScreen(
                     loading = true
                     scope.launch {
                         try {
+                            val trimmedName = displayName.trim()
+                            if (trimmedName.isEmpty()) {
+                                error = "이름을 다시 입력해주세요."
+                                return@launch
+                            }
                             val tag = tagInput.trim().removePrefix("@")
+
+                            repo.updateUsername(trimmedName)
+                                .onFailure { e ->
+                                    error = parseSettingsApiError(e.message) ?: "이름 설정에 실패했습니다."
+                                    return@launch
+                                }
+
                             repo.updateTag(tag)
                                 .onSuccess {
                                     if (continueTutorial) {

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/KillingPartSelector.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/KillingPartSelector.kt
@@ -62,7 +62,8 @@ fun KillingPartSelector(
     /** 첫 레이아웃 시 선택 구간 (다른 영상으로 바꿀 때 부모에서 넘김) */
     initialStartSec: Float = 0f,
     initialDurationSec: Float = 10f,
-    onStartChange: (start: Float, end: Float, duration: Float) -> Unit
+    onStartChange: (start: Float, end: Float, duration: Float) -> Unit,
+    onHandleAdjusted: ((handleSide: String) -> Unit)? = null
 ) {
     val scrollState = rememberScrollState()
     val density = LocalDensity.current
@@ -139,18 +140,42 @@ fun KillingPartSelector(
     val durationSec = (endTime - startTime).coerceAtLeast(0f)
     var miniMapWidthPx by remember { mutableStateOf(0f) }
     var wasScrolling by remember { mutableStateOf(false) }
+    val latestOnHandleAdjusted by rememberUpdatedState(onHandleAdjusted)
+
+    fun currentSelection(): Triple<Float, Float, Float> {
+        val sx = scrollState.value.toFloat()
+        val s = ((sx + leftHandleX) / pxPerSecond).coerceIn(0f, totalDuration.toFloat())
+        val e = ((sx + rightHandleX) / pxPerSecond).coerceIn(0f, totalDuration.toFloat())
+        val d = (e - s).coerceAtLeast(0f)
+        return Triple(s, e, d)
+    }
 
     fun commitSelectionIfNeeded() {
+        val (s, e, d) = currentSelection()
         val changed =
-            startTime != lastCommittedStart ||
-                endTime != lastCommittedEnd ||
-                durationSec != lastCommittedDuration
+            s != lastCommittedStart ||
+                e != lastCommittedEnd ||
+                d != lastCommittedDuration
 
         if (changed) {
-            onStartChange(startTime, endTime, durationSec)
-            lastCommittedStart = startTime
-            lastCommittedEnd = endTime
-            lastCommittedDuration = durationSec
+            onStartChange(s, e, d)
+            lastCommittedStart = s
+            lastCommittedEnd = e
+            lastCommittedDuration = d
+        }
+    }
+
+    fun endHandleDrag(handleSide: String) {
+        val beforeStart = lastCommittedStart
+        val beforeEnd = lastCommittedEnd
+        val beforeDuration = lastCommittedDuration
+        commitSelectionIfNeeded()
+        val changed =
+            beforeStart != lastCommittedStart ||
+                beforeEnd != lastCommittedEnd ||
+                beforeDuration != lastCommittedDuration
+        if (changed) {
+            latestOnHandleAdjusted?.invoke(handleSide)
         }
     }
 
@@ -215,8 +240,8 @@ fun KillingPartSelector(
                     .offset { IntOffset(leftHandleX.roundToInt(), handleYOffsetPx) }
                     .pointerInput(Unit) {
                         detectDragGestures(
-                            onDragEnd = { commitSelectionIfNeeded() },
-                            onDragCancel = { commitSelectionIfNeeded() }
+                            onDragEnd = { endHandleDrag("left") },
+                            onDragCancel = { endHandleDrag("left") }
                         ) { change, drag ->
                             change.consume()
 
@@ -277,8 +302,8 @@ fun KillingPartSelector(
                     .offset { IntOffset(rightHandleX.roundToInt(), handleYOffsetPx) }
                     .pointerInput(Unit) {
                         detectDragGestures(
-                            onDragEnd = { commitSelectionIfNeeded() },
-                            onDragCancel = { commitSelectionIfNeeded() }
+                            onDragEnd = { endHandleDrag("right") },
+                            onDragCancel = { endHandleDrag("right") }
                         ) { change, drag ->
                             change.consume()
 
@@ -409,17 +434,29 @@ fun KillingPartSelector(
                                     .coerceAtMost(maxDurationSec)
                             },
                             onDragEnd = {
-                                onStartChange(
-                                    latestMiniMapTargetStartSec,
-                                    (latestMiniMapTargetStartSec + latestMiniMapTargetDurationSec)
-                                        .coerceAtMost(totalDuration.toFloat()),
-                                    latestMiniMapTargetDurationSec
-                                )
-                                lastCommittedStart = latestMiniMapTargetStartSec
-                                lastCommittedEnd =
+                                if (dragAccumulatedPx == 0f) return@detectDragGestures
+
+                                val beforeStart = lastCommittedStart
+                                val beforeEnd = lastCommittedEnd
+                                val beforeDuration = lastCommittedDuration
+                                val newStart = latestMiniMapTargetStartSec
+                                val newEnd =
                                     (latestMiniMapTargetStartSec + latestMiniMapTargetDurationSec)
                                         .coerceAtMost(totalDuration.toFloat())
-                                lastCommittedDuration = latestMiniMapTargetDurationSec
+                                val newDuration = latestMiniMapTargetDurationSec
+
+                                onStartChange(newStart, newEnd, newDuration)
+                                lastCommittedStart = newStart
+                                lastCommittedEnd = newEnd
+                                lastCommittedDuration = newDuration
+
+                                val changed =
+                                    beforeStart != lastCommittedStart ||
+                                        beforeEnd != lastCommittedEnd ||
+                                        beforeDuration != lastCommittedDuration
+                                if (changed) {
+                                    latestOnHandleAdjusted?.invoke("spectrum_bar")
+                                }
                             },
                             onDragCancel = { commitSelectionIfNeeded() }
                         ) { change, drag ->

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/SelectDurationScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/SelectDurationScreen.kt
@@ -54,6 +54,7 @@ import com.killingpart.killingpoint.ui.screen.WriteDiaryScreen.AlbumDiaryBoxWith
 import com.killingpart.killingpoint.data.model.Diary
 import com.killingpart.killingpoint.data.model.Scope
 import com.killingpart.killingpoint.ui.component.BottomBar
+import com.killingpart.killingpoint.analytics.KillingPartCutAnalytics
 import com.killingpart.killingpoint.analytics.OnboardingAnalytics
 import com.killingpart.killingpoint.navigation.navigateToMainClearingStack
 import androidx.compose.material3.TextButton
@@ -171,6 +172,8 @@ fun SelectDurationScreen(
 
     val scrollState = rememberScrollState()
     val navigateNext: () -> Unit = {
+        KillingPartCutAnalytics.cutCompleted()
+
         val encodedVideoUrl = Uri.encode(currentVideoUrl ?: "")
         val tutorialArg = if (tutorialMode) "true" else "false"
 
@@ -363,6 +366,9 @@ fun SelectDurationScreen(
                                 start = s
                                 end = e
                                 duration = d
+                            },
+                            onHandleAdjusted = { handleSide ->
+                                KillingPartCutAnalytics.cutHandleAdjusted(handleSide)
                             }
                         )
                     }

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/WriteDiaryScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/WriteDiaryScreen.kt
@@ -44,6 +44,7 @@ import com.killingpart.killingpoint.ui.screen.AddMusicScreen.korean_font_medium
 import com.killingpart.killingpoint.data.model.Diary
 import com.killingpart.killingpoint.data.model.Scope
 import com.killingpart.killingpoint.ui.component.BottomBar
+import com.killingpart.killingpoint.analytics.KillingPartCutAnalytics
 import com.killingpart.killingpoint.analytics.OnboardingAnalytics
 import com.killingpart.killingpoint.navigation.navigateToMainClearingStack
 import com.killingpart.killingpoint.ui.theme.PaperlogyFontFamily
@@ -321,10 +322,12 @@ fun WriteDiaryScreen(
                         }.onSuccess {
                             android.util.Log.d("WriteDiaryScreen", "Diary created successfully")
                             if (tutorialMode) {
+                                KillingPartCutAnalytics.onboardingKillingpartCutCompleted()
                                 navController.navigate("onboarding_home_preview") {
                                     popUpTo("onboarding_kp_intro") { inclusive = false }
                                 }
                             } else {
+                                KillingPartCutAnalytics.killingpartCutCompleted()
                                 navController.navigate("main")
                             }
                         }.onFailure { e ->


### PR DESCRIPTION
# 변경점 👍
- 킬링파트의 구간 자르기 스텝에서의 단계별로 이벤트로그를 심었습니다.
- 로그를 심는 세부 단위들은 다음과 같습니다.
<img width="778" height="802" alt="image" src="https://github.com/user-attachments/assets/bfea5cdc-90dc-4449-8bb9-de878a506a21" />


<img width="1214" height="618" alt="image" src="https://github.com/user-attachments/assets/ac89a43f-0cd2-4333-9225-1a4c845d1e0d" />

- 온보딩 과정에서의 구간 자르기에서도 동일하게 로그가 남고, 마지막 최종 완료시에는 일반 구간자르기와는 다르게 'onboarding_killingpart_cut_completed' 로 표시됩니다.

<img width="1223" height="511" alt="image" src="https://github.com/user-attachments/assets/35aed1b2-1131-4878-b279-eb819fc8936f" />
