### PR TITLE
탭 체류 시간 및 탐색 탭 이벤트 로그 추가

### DIFF
--- a/app/src/main/java/com/killingpart/killingpoint/MainActivity.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/MainActivity.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
 import com.kakao.sdk.common.KakaoSdk
 import com.killingpart.killingpoint.BuildConfig
+import com.killingpart.killingpoint.analytics.EngagementAnalytics
 import com.killingpart.killingpoint.analytics.OnboardingAnalytics
 import com.killingpart.killingpoint.data.repository.AuthRepository
 import com.killingpart.killingpoint.navigation.NavGraph
@@ -160,6 +161,9 @@ class MainActivity : ComponentActivity() {
 
                         LaunchedEffect(startDestination, resolvedStartDestination) {
                             if (resolvedStartDestination != null && startDestination != "home") {
+                                if (startDestination == "main" || startDestination.startsWith("main?")) {
+                                    EngagementAnalytics.markAppOpenedOnMyTab()
+                                }
                                 navController.navigate(startDestination) {
                                     popUpTo(0) { inclusive = true }
                                 }

--- a/app/src/main/java/com/killingpart/killingpoint/analytics/EngagementAnalytics.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/analytics/EngagementAnalytics.kt
@@ -1,0 +1,51 @@
+package com.killingpart.killingpoint.analytics
+
+object EngagementAnalytics {
+    object MainTab {
+        const val MY = "my"
+        const val EXPLORE = "explore"
+        const val SOCIAL = "social"
+        const val ADD = "add"
+    }
+
+    private var activeTab: String? = null
+    private var activeTabSinceMs: Long = 0L
+
+    fun exploreFeedCardViewed(feedIndex: Int) {
+        AmplitudeAnalytics.track(
+            "explore_feed_card_viewed",
+            mapOf("feed_index" to feedIndex)
+        )
+    }
+
+    /** 앱 오픈 후 MY 탭 자동 진입 시 타이머만 시작하고 이벤트는 보내지 않는다. */
+    fun markAppOpenedOnMyTab() {
+        activeTab = MainTab.MY
+        activeTabSinceMs = System.currentTimeMillis()
+    }
+
+    /** 하단 탭 화면이 표시될 때 머무름 시간 계산 기준을 갱신한다. (이벤트 미전송) */
+    fun onMainTabScreenVisible(tab: String) {
+        if (activeTab != tab) {
+            activeTab = tab
+            activeTabSinceMs = System.currentTimeMillis()
+        }
+    }
+
+    fun mainTabSelected(tab: String) {
+        val properties = mutableMapOf<String, Any>("tab" to tab)
+        activeTab?.let { previousTab ->
+            val stayDurationSec =
+                ((System.currentTimeMillis() - activeTabSinceMs) / 1000).coerceAtLeast(0)
+            properties["stay_duration_sec"] = stayDurationSec
+            if (previousTab != tab) {
+                properties["previous_tab"] = previousTab
+            }
+        }
+
+        AmplitudeAnalytics.track("main_tab_selected", properties)
+
+        activeTab = tab
+        activeTabSinceMs = System.currentTimeMillis()
+    }
+}

--- a/app/src/main/java/com/killingpart/killingpoint/ui/component/BottomBar.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/component/BottomBar.kt
@@ -26,12 +26,18 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
+import com.killingpart.killingpoint.analytics.EngagementAnalytics
 import com.killingpart.killingpoint.R
 import com.killingpart.killingpoint.ui.theme.PaperlogyFontFamily
 import com.killingpart.killingpoint.ui.theme.UnboundedFontFamily
 
 @Composable
 fun BottomBar(navController: NavController, modifier: Modifier = Modifier) {
+    fun selectTab(tab: String, navigate: () -> Unit) {
+        EngagementAnalytics.mainTabSelected(tab)
+        navigate()
+    }
+
     Row (
         modifier = Modifier.fillMaxWidth()
             .background(color = Color.Black)
@@ -43,7 +49,11 @@ fun BottomBar(navController: NavController, modifier: Modifier = Modifier) {
         Column (
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.clickable { navController.navigate("main")}
+            modifier = Modifier.clickable {
+                selectTab(EngagementAnalytics.MainTab.MY) {
+                    navController.navigate("main")
+                }
+            }
         ){
             Image(
                 painter = painterResource(id = R.drawable.navi_home),
@@ -61,12 +71,17 @@ fun BottomBar(navController: NavController, modifier: Modifier = Modifier) {
 
         Column (
             verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.clickable {
+                selectTab(EngagementAnalytics.MainTab.EXPLORE) {
+                    navController.navigate("search")
+                }
+            }
         ){
             Image(
                 painter = painterResource(id = R.drawable.navi_search),
                 contentDescription = "탐색 네비게이션 바",
-                modifier = Modifier.size(36.dp).clickable {navController.navigate("search")}
+                modifier = Modifier.size(36.dp)
             )
             Text(
                 text = "탐색",
@@ -83,7 +98,11 @@ fun BottomBar(navController: NavController, modifier: Modifier = Modifier) {
             Image(
                 painter = painterResource(id = R.drawable.navi_add),
                 contentDescription = "추가 네비게이션 바",
-                modifier = Modifier.size(36.dp).clickable { navController.navigate("add_music?tutorial=false") }
+                modifier = Modifier.size(36.dp).clickable {
+                    selectTab(EngagementAnalytics.MainTab.ADD) {
+                        navController.navigate("add_music?tutorial=false")
+                    }
+                }
             )
             Text(
                 text = "추가",
@@ -97,7 +116,9 @@ fun BottomBar(navController: NavController, modifier: Modifier = Modifier) {
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.clickable {
-                navController.navigate("social?tab=feed&friendListTab=picks")
+                selectTab(EngagementAnalytics.MainTab.SOCIAL) {
+                    navController.navigate("social?tab=feed&friendListTab=picks")
+                }
             }
         ){
             Image(

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/AddMusicScreen/AddMusicScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/AddMusicScreen/AddMusicScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.TextButton
 import androidx.compose.ui.text.font.FontWeight
+import com.killingpart.killingpoint.analytics.EngagementAnalytics
 import com.killingpart.killingpoint.analytics.KillingPartCutAnalytics
 import com.killingpart.killingpoint.analytics.OnboardingAnalytics
 import com.killingpart.killingpoint.navigation.navigateToMainClearingStack
@@ -109,8 +110,11 @@ fun AddMusicScreen(
     var globalLoading by remember { mutableStateOf(false) }
     val bg = if (tutorialMode) Color.Black else Color(0xFF1D1E20)
 
-    LaunchedEffect(Unit) {
-        KillingPartCutAnalytics.killingpartCutStarted()
+    LaunchedEffect(tutorialMode) {
+        if (!tutorialMode) {
+            EngagementAnalytics.onMainTabScreenVisible(EngagementAnalytics.MainTab.ADD)
+            KillingPartCutAnalytics.killingpartCutStarted()
+        }
     }
     
     Box(

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/MainScreen/MainScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/MainScreen/MainScreen.kt
@@ -60,6 +60,7 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import coil.compose.AsyncImage
 import com.killingpart.killingpoint.R
+import com.killingpart.killingpoint.analytics.EngagementAnalytics
 import com.killingpart.killingpoint.ui.component.AppBackground
 import com.killingpart.killingpoint.ui.component.BottomBar
 import com.killingpart.killingpoint.ui.component.LoadingVideo
@@ -117,6 +118,7 @@ fun MainScreen(navController: NavController, initialTab: String = "play", initia
     val context = androidx.compose.ui.platform.LocalContext.current
 
     LaunchedEffect(Unit) {
+        EngagementAnalytics.onMainTabScreenVisible(EngagementAnalytics.MainTab.MY)
         diaryViewModel.loadDiaries(context)
         userViewModel.loadUserInfo(context)
         

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/SearchScreen/SearchScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/SearchScreen/SearchScreen.kt
@@ -31,6 +31,7 @@ import androidx.navigation.NavController
 import com.killingpart.killingpoint.data.model.FeedDiary
 import com.killingpart.killingpoint.data.model.DiaryLikeUser
 import com.killingpart.killingpoint.ui.component.AppBackground
+import com.killingpart.killingpoint.analytics.EngagementAnalytics
 import com.killingpart.killingpoint.ui.component.BottomBar
 import com.killingpart.killingpoint.ui.component.LikesModal
 import com.killingpart.killingpoint.ui.screen.MainScreen.MusicTimeBar
@@ -59,8 +60,11 @@ fun SearchScreen(navController: NavController) {
     var likesError by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(Unit) {
+        EngagementAnalytics.onMainTabScreenVisible(EngagementAnalytics.MainTab.EXPLORE)
         searchViewModel.loadRandomDiaries(context)
     }
+
+    val viewedFeedDiaryIds = remember { mutableSetOf<Long>() }
 
     // 탐색 탭 좋아요 목록 데이터 로드
     LaunchedEffect(likesDiaryId) {
@@ -94,6 +98,22 @@ fun SearchScreen(navController: NavController) {
     }
 
     val snapFlingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
+
+    LaunchedEffect(currentItemIndex.value, searchState) {
+        val state = searchState as? SearchUiState.Success ?: return@LaunchedEffect
+        val index = currentItemIndex.value
+        if (index >= state.diaries.size) return@LaunchedEffect
+
+        val feedDiary = state.diaries[index]
+        val diaryId = feedDiary.diaryId ?: return@LaunchedEffect
+        if (diaryId in viewedFeedDiaryIds) return@LaunchedEffect
+
+        delay(300)
+        if (currentItemIndex.value != index) return@LaunchedEffect
+
+        viewedFeedDiaryIds.add(diaryId)
+        EngagementAnalytics.exploreFeedCardViewed(index)
+    }
 
     AppBackground {
         Column(

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/SocialScreen/SocialScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/SocialScreen/SocialScreen.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.compose.runtime.saveable.rememberSaveable
 import com.killingpart.killingpoint.R
+import com.killingpart.killingpoint.analytics.EngagementAnalytics
 import com.killingpart.killingpoint.ui.component.AppBackground
 import com.killingpart.killingpoint.ui.component.BottomBar
 import com.killingpart.killingpoint.ui.screen.MainScreen.TopPillTabs
@@ -54,6 +55,7 @@ fun SocialScreen(
     }
 
     LaunchedEffect(Unit) {
+        EngagementAnalytics.onMainTabScreenVisible(EngagementAnalytics.MainTab.SOCIAL)
         alarmViewModel.refreshAlarmFlag(context)
     }
 


### PR DESCRIPTION
# 변경점 👍
### 1. explore_feed_card_viewed
- 위치: SearchScreen (탐색 탭)
- 시점: 카드가 화면에 노출된 뒤 300ms 후 (곡 정보, 유튜브 영역 렌더링 대기)
- 속성: feed_index (0부터 시작)
- 중복 방지: diaryId 기준으로 세션 내 1회만 전송
### 2. main_tab_selected
- 위치: BottomBar 탭 클릭
- 속성:
  - tab: my / explore / social / add
  - previous_tab: 이전 탭 (있을 때)
  - stay_duration_sec: 이전 탭 체류 시간(초) — 비고 요구사항 반영
- 제외 조건:
  - 앱 오픈 후 MY 자동 진입 → 이벤트 미전송 (MainActivity에서 markAppOpenedOnMyTab())
  - MY 내부 서브탭(내 컬렉션/재생/캘린더) 전환 → BottomBar 미사용이라 미전송

<img width="1425" height="672" alt="image" src="https://github.com/user-attachments/assets/cb3ddbbb-cc48-4442-86d5-924ece9627c0" />
<img width="1512" height="699" alt="image" src="https://github.com/user-attachments/assets/b44f8d44-d925-4e67-95c7-4c2e9bdf2b16" />
