### PR TITLE
[QA/Chore] QA반영 및 세부 ui 수정 

### DIFF
--- a/app/src/main/java/com/killingpart/killingpoint/ui/component/LikesModal.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/component/LikesModal.kt
@@ -94,7 +94,7 @@ fun LikesModal(
                 color = Color.White,
                 fontFamily = PaperlogyFontFamily,
                 fontWeight = FontWeight.W500,
-                fontSize = 16.sp,
+                fontSize = 12.sp,
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center
             )
@@ -179,45 +179,45 @@ fun LikesModal(
                     }
 
                     LazyColumn(
-                        modifier = Modifier.fillMaxWidth().heightIn(max = 320.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                        modifier = Modifier.fillMaxWidth().heightIn(max = 280.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp)
                     ) {
                         items(filteredUsers.size) { index ->
                             val user = filteredUsers[index]
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .clip(RoundedCornerShape(12.dp))
+                                    .clip(RoundedCornerShape(8.dp))
                                     .background(Color(0xFF090909))
                                     .clickable { onUserClick(user) }
-                                    .padding(horizontal = 14.dp, vertical = 12.dp),
+                                    .padding(horizontal = 10.dp, vertical = 7.dp),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
                                 AsyncImage(
                                     model = user.profileImageUrl,
                                     contentDescription = user.username,
                                     modifier = Modifier
-                                        .size(40.dp)
+                                        .size(32.dp)
                                         .clip(RoundedCornerShape(50))
-                                        .border(2.dp, mainGreen, RoundedCornerShape(50)),
+                                        .border(1.5.dp, mainGreen, RoundedCornerShape(50)),
                                     contentScale = ContentScale.Crop,
                                     placeholder = painterResource(id = R.drawable.default_profile),
                                     error = painterResource(id = R.drawable.default_profile)
                                 )
-                                Spacer(modifier = Modifier.width(12.dp))
-                                Column {
+                                Spacer(modifier = Modifier.width(10.dp))
+                                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                                     Text(
                                         text = user.username,
                                         color = Color.White,
                                         fontFamily = PaperlogyFontFamily,
                                         fontWeight = FontWeight.W500,
-                                        fontSize = 14.sp
+                                        fontSize = 12.sp
                                     )
                                     Text(
                                         text = "@${user.tag}",
                                         color = Color(0xFF888888),
                                         fontFamily = PaperlogyFontFamily,
-                                        fontSize = 11.sp
+                                        fontSize = 9.sp
                                     )
                                 }
                             }

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/ArchiveScreen/DiaryCard.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/ArchiveScreen/DiaryCard.kt
@@ -1,6 +1,7 @@
 package com.killingpart.killingpoint.ui.screen.ArchiveScreen
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -29,6 +30,7 @@ import com.killingpart.killingpoint.R
 import com.killingpart.killingpoint.data.model.Diary
 import com.killingpart.killingpoint.data.model.Scope
 import com.killingpart.killingpoint.ui.theme.PaperlogyFontFamily
+import com.killingpart.killingpoint.ui.theme.mainGreen
 import androidx.compose.material3.Surface
 
 @Composable
@@ -59,59 +61,20 @@ fun DiaryCard(
             .fillMaxWidth()
             .then(clickableModifier)
     ) {
-        // 상단: authorTag 있으면 @{tag}, 없으면 좋아요 + 공개 범위 아이콘
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 4.dp)
-                .padding(horizontal = 3.dp),
-            horizontalArrangement = if (authorTag != null) Arrangement.Start else Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            if (authorTag != null) {
-                Text(
-                    text = "@$authorTag",
-                    color = Color.White,
-                    fontSize = 10.sp,
-                    fontFamily = PaperlogyFontFamily,
-                    fontWeight = FontWeight.Medium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            } else {
-                // 좋아요 수
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.clickable { onLikeClick?.invoke() }
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.Favorite,
-                        contentDescription = "Likes",
-                        tint = Color(0xFFCCFF33),
-                        modifier = Modifier.size(15.dp)
-                    )
-                    Spacer(modifier = Modifier.width(3.dp))
-                    Text(
-                        text = "${diary.likeCount}",
-                        color = Color.White,
-                        fontSize = 10.sp,
-                        fontFamily = PaperlogyFontFamily,
-                        fontWeight = FontWeight.Medium
-                    )
-                }
-
-                // 공개 범위 아이콘
-                Icon(
-                    imageVector = when (diary.scope) {
-                        Scope.PUBLIC -> Icons.Filled.Language
-                        Scope.PRIVATE -> Icons.Filled.Lock
-                        Scope.KILLING_PART -> Icons.Filled.MusicNote
-                    },
-                    contentDescription = "Scope",
-                    tint = Color.White,
-                    modifier = Modifier.size(15.dp)
-                )
-            }
+        if (authorTag != null) {
+            Text(
+                text = "@$authorTag",
+                color = Color.White,
+                fontSize = 10.sp,
+                fontFamily = PaperlogyFontFamily,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 4.dp)
+                    .padding(horizontal = 3.dp)
+            )
         }
         
         Box(
@@ -139,6 +102,59 @@ fun DiaryCard(
                     )
             )
 
+            val likeBadgeShape = RoundedCornerShape(50)
+            val isLiked = diary.isLiked
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(6.dp)
+                    .then(
+                        if (isLiked) {
+                            Modifier
+                                .background(mainGreen.copy(alpha = 0.25f), likeBadgeShape)
+                                .border(1.dp, mainGreen, likeBadgeShape)
+                        } else {
+                            Modifier
+                                .background(Color(0xFF1A1A1A), likeBadgeShape)
+                                .border(1.dp, Color.White.copy(alpha = 0.4f), likeBadgeShape)
+                        }
+                    )
+                    .clickable { onLikeClick?.invoke() }
+                    .padding(horizontal = 6.dp, vertical = 3.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Favorite,
+                    contentDescription = "Likes",
+                    tint = if (isLiked) mainGreen else Color.White,
+                    modifier = Modifier.size(10.dp)
+                )
+                Spacer(modifier = Modifier.width(3.dp))
+                Text(
+                    text = "${diary.likeCount}",
+                    color = if (isLiked) mainGreen else Color.White,
+                    fontSize = 10.sp,
+                    fontFamily = PaperlogyFontFamily,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+
+            if (authorTag == null) {
+                Icon(
+                    imageVector = when (diary.scope) {
+                        Scope.PUBLIC -> Icons.Filled.Language
+                        Scope.PRIVATE -> Icons.Filled.Lock
+                        Scope.KILLING_PART -> Icons.Filled.MusicNote
+                    },
+                    contentDescription = "Scope",
+                    tint = Color.White,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(6.dp)
+                        .size(15.dp)
+                )
+            }
         }
         
         // 하단 텍스트 정보 (이미지 아래)
@@ -209,12 +225,27 @@ fun DiaryCardPreview() {
                 start = "string",
                 end = "string",
                 createDate = "1999.12.12",
-                updateDate = "string"
+                updateDate = "string",
+                isLiked = true,
+                likeCount = 12
+            )
+
+            val mockDiaryNotLiked = mockDiary.copy(
+                musicTitle = "Another Song",
+                isLiked = false,
+                likeCount = 125
             )
             
-            DiaryCard(
-                diary = mockDiary
-            )
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                DiaryCard(
+                    diary = mockDiary,
+                    modifier = Modifier.weight(1f)
+                )
+                DiaryCard(
+                    diary = mockDiaryNotLiked,
+                    modifier = Modifier.weight(1f)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/ArchiveScreen/DiaryCard.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/ArchiveScreen/DiaryCard.kt
@@ -133,7 +133,8 @@ fun DiaryCard(
                 Spacer(modifier = Modifier.width(3.dp))
                 Text(
                     text = "${diary.likeCount}",
-                    color = if (isLiked) mainGreen else Color.White,
+                    // color = if (isLiked) mainGreen else Color.White,
+                    color = Color.White,
                     fontSize = 10.sp,
                     fontFamily = PaperlogyFontFamily,
                     fontWeight = FontWeight.Medium

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/ArchiveScreen/OuterBox.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/ArchiveScreen/OuterBox.kt
@@ -40,6 +40,7 @@ import com.killingpart.killingpoint.ui.screen.ArchiveScreen.DiaryCard
 import android.net.Uri
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
 import androidx.compose.ui.text.style.TextAlign
 import com.killingpart.killingpoint.ui.theme.PaperlogyFontFamily
 import com.killingpart.killingpoint.ui.theme.mainGreen
@@ -47,6 +48,8 @@ import com.killingpart.killingpoint.ui.viewmodel.UserUiState
 import com.killingpart.killingpoint.ui.viewmodel.UserViewModel
 import com.killingpart.killingpoint.data.repository.AuthRepository
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
 import androidx.compose.ui.input.pointer.pointerInput
 import com.killingpart.killingpoint.ui.component.LikesModal
 
@@ -198,7 +201,7 @@ fun OuterBox(
                                 contentDescription = "프로필 사진",
                                 contentScale = ContentScale.Crop,
                                 modifier = Modifier
-                                    .size(60.dp)
+                                    .size(50.dp)
                                     .clip(RoundedCornerShape(50))
                                     .border(3.dp, mainGreen, RoundedCornerShape(50)),
                                 placeholder = painterResource(id = R.drawable.default_profile),
@@ -212,7 +215,7 @@ fun OuterBox(
                                 contentDescription = "프로필 사진",
                                 contentScale = ContentScale.Crop,
                                 modifier = Modifier
-                                    .size(60.dp)
+                                    .size(50.dp)
                                     .clip(RoundedCornerShape(50))
                                     .border(3.dp, mainGreen, RoundedCornerShape(50))
                             )
@@ -233,7 +236,7 @@ fun OuterBox(
                             },
                             fontFamily = PaperlogyFontFamily,
                             fontWeight = FontWeight.W400,
-                            fontSize = 14.sp,
+                            fontSize = 12.sp,
                             color = mainGreen,
                             maxLines = 1,
                             overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
@@ -247,7 +250,7 @@ fun OuterBox(
                             },
                             fontFamily = PaperlogyFontFamily,
                             fontWeight = FontWeight.W400,
-                            fontSize = 12.sp,
+                            fontSize = 10.sp,
                             color = mainGreen,
                             maxLines = 1,
                             overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
@@ -269,7 +272,7 @@ fun OuterBox(
                             text = "${userStatistics?.killingPartCount ?: diaries.size}",
                             fontFamily = PaperlogyFontFamily,
                             fontWeight = FontWeight.W400,
-                            fontSize = 16.sp,
+                            fontSize = 13.sp,
                             color = mainGreen,
                             textAlign = androidx.compose.ui.text.style.TextAlign.Center
                         )
@@ -278,7 +281,7 @@ fun OuterBox(
                             text = "킬링파트",
                             fontFamily = PaperlogyFontFamily,
                             fontWeight = FontWeight.W400,
-                            fontSize = 10.sp,
+                            fontSize = 8.sp,
                             color = mainGreen,
                             textAlign = androidx.compose.ui.text.style.TextAlign.Center
                         )
@@ -302,7 +305,7 @@ fun OuterBox(
                             text = "${userStatistics?.fanCount ?: 0}",
                             fontFamily = PaperlogyFontFamily,
                             fontWeight = FontWeight.W400,
-                            fontSize = 16.sp,
+                            fontSize = 13.sp,
                             color = mainGreen,
                             textAlign = androidx.compose.ui.text.style.TextAlign.Center
                         )
@@ -311,7 +314,7 @@ fun OuterBox(
                             text = "팬덤",
                             fontFamily = PaperlogyFontFamily,
                             fontWeight = FontWeight.W400,
-                            fontSize = 10.sp,
+                            fontSize = 8.sp,
                             color = mainGreen,
                             textAlign = androidx.compose.ui.text.style.TextAlign.Center
                         )
@@ -335,7 +338,7 @@ fun OuterBox(
                             text = "${userStatistics?.pickCount ?: 0}",
                             fontFamily = PaperlogyFontFamily,
                             fontWeight = FontWeight.W400,
-                            fontSize = 16.sp,
+                            fontSize = 13.sp,
                             color = mainGreen,
                             textAlign = androidx.compose.ui.text.style.TextAlign.Center
                         )
@@ -344,7 +347,7 @@ fun OuterBox(
                             text = "PICKS",
                             fontFamily = PaperlogyFontFamily,
                             fontWeight = FontWeight.W400,
-                            fontSize = 10.sp,
+                            fontSize = 8.sp,
                             color = mainGreen,
                             textAlign = androidx.compose.ui.text.style.TextAlign.Center
                         )
@@ -373,6 +376,13 @@ fun OuterBox(
                         shape = RoundedCornerShape(10.dp),
                         contentPadding = PaddingValues(horizontal = 12.dp, vertical = 0.dp)
                     ) {
+                        Icon(
+                            imageVector = Icons.Filled.Settings,
+                            contentDescription = null,
+                            tint = mainGreen,
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
                         Text(
                             text = "설정",
                             color = mainGreen,

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/DiaryDetailScreen/AlbumDiaryBoxWithTimeBar.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/DiaryDetailScreen/AlbumDiaryBoxWithTimeBar.kt
@@ -116,21 +116,12 @@ fun AlbumDiaryBoxWithTimeBar(
                 verticalArrangement = Arrangement.Center
             ) {
                 track?.title?.let { title ->
-//                    Text(
-//                        text = title,
-//                        fontFamily = PaperlogyFontFamily,
-//                        fontWeight = FontWeight.Bold,
-//                        fontSize = 16.sp,
-//                        color = Color.White,
-//                        maxLines = 1,
-//                        overflow = TextOverflow.Ellipsis
-//                    )
                     ScrollableText(
                         text = title,
                         modifier = Modifier.fillMaxWidth(),
                         fontFamily = PaperlogyFontFamily,
                         fontWeight = FontWeight.Bold,
-                        fontSize = 16.sp,
+                        fontSize = 13.sp,
                         color = Color.White,
                     )
                 }
@@ -138,19 +129,12 @@ fun AlbumDiaryBoxWithTimeBar(
                 Spacer(modifier = Modifier.height(8.dp))
 
                 track?.artist?.let { artist ->
-//                    Text(
-//                        text = artist,
-//                        fontFamily = PaperlogyFontFamily,
-//                        fontWeight = FontWeight.Medium,
-//                        fontSize = 12.sp,
-//                        color = Color.White
-//                    )
                     ScrollableText(
                         text = artist,
                         modifier = Modifier.fillMaxWidth(),
                         fontFamily = PaperlogyFontFamily,
                         fontWeight = FontWeight.Bold,
-                        fontSize = 13.sp,
+                        fontSize = 11.sp,
                         color = Color.White,
                     )
                 }

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/DiaryDetailScreen/DiaryDetailScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/DiaryDetailScreen/DiaryDetailScreen.kt
@@ -2,8 +2,10 @@ package com.killingpart.killingpoint.ui.screen.DiaryDetailScreen
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -11,6 +13,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Check
@@ -49,6 +52,8 @@ import coil.compose.AsyncImage
 import com.killingpart.killingpoint.R
 import com.killingpart.killingpoint.ui.component.AppBackground
 import com.killingpart.killingpoint.ui.component.BottomBar
+import com.killingpart.killingpoint.ui.component.LikesModal
+import com.killingpart.killingpoint.data.model.DiaryLikeUser
 import com.killingpart.killingpoint.data.model.CreateDiaryRequest
 import com.killingpart.killingpoint.data.model.Scope
 import com.killingpart.killingpoint.data.repository.AuthRepository
@@ -61,6 +66,8 @@ import com.killingpart.killingpoint.data.model.Diary
 import com.killingpart.killingpoint.ui.screen.MainScreen.YouTubePlayerBox
 import kotlinx.coroutines.launch
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.zIndex
 import androidx.compose.ui.Alignment
 import com.killingpart.killingpoint.data.spotify.SimpleTrack
 import java.net.URLDecoder
@@ -102,8 +109,43 @@ fun DiaryDetailScreen(
     var showDeleteDialog by remember { mutableStateOf(false) }
     var isDeleting by remember { mutableStateOf(false) }
 
+    val isOtherPersonDiary = diaryId != null &&
+        authorUsername.isNotEmpty() &&
+        authorTag.isNotEmpty()
+
+    var isLiked by remember { mutableStateOf(false) }
+    var likeCount by remember { mutableStateOf(0) }
+    var isStored by remember { mutableStateOf(false) }
+    var likesDiaryId by remember { mutableStateOf<Long?>(null) }
+    var likesUsers by remember { mutableStateOf<List<DiaryLikeUser>>(emptyList()) }
+    var isLoadingLikes by remember { mutableStateOf(false) }
+    var likesError by remember { mutableStateOf<String?>(null) }
+
     LaunchedEffect(Unit) {
         userViewModel.loadUserInfo(context)
+    }
+
+    LaunchedEffect(diaryId, isOtherPersonDiary) {
+        if (!isOtherPersonDiary || diaryId == null) return@LaunchedEffect
+        repo.getDiaryDetail(diaryId).onSuccess { detail ->
+            isLiked = detail.isLiked
+            likeCount = detail.likeCount
+            isStored = detail.isStored
+        }
+    }
+
+    LaunchedEffect(likesDiaryId) {
+        val targetDiaryId = likesDiaryId ?: return@LaunchedEffect
+        isLoadingLikes = true
+        likesError = null
+        repo.getDiaryLikes(diaryId = targetDiaryId, page = 0, size = 50, searchCond = null)
+            .onSuccess { response ->
+                likesUsers = response.content
+            }
+            .onFailure { e ->
+                likesError = e.message
+            }
+        isLoadingLikes = false
     }
     
     // content가 변경되면 currentContent와 editedContent도 업데이트
@@ -218,10 +260,12 @@ fun DiaryDetailScreen(
         Column(
             modifier = Modifier.fillMaxSize()
         ) {
+            Spacer(modifier = Modifier.height(35.dp))
+
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 20.dp, vertical = 20.dp),
+                    .padding(horizontal = 20.dp, vertical = 10.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -302,8 +346,7 @@ fun DiaryDetailScreen(
                 }
 
                 if (!isEditing) {
-                    val isFriendProfile = authorUsername.isNotEmpty() && authorTag.isNotEmpty()
-                    if (diaryId != null && !isFriendProfile) {
+                    if (diaryId != null && !isOtherPersonDiary) {
                         Row {
                             IconButton(
                                 onClick = { showDeleteDialog = true }
@@ -324,6 +367,8 @@ fun DiaryDetailScreen(
                                 )
                             }
                         }
+                    } else if (isOtherPersonDiary) {
+                        Spacer(modifier = Modifier.width(48.dp))
                     } else {
                         Spacer(modifier = Modifier.width(48.dp))
                     }
@@ -332,7 +377,111 @@ fun DiaryDetailScreen(
                 }
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
+            if (isOtherPersonDiary && !isEditing) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        val likeBadgeShape = RoundedCornerShape(50)
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center,
+                            modifier = Modifier
+                                .then(
+                                    if (isLiked) {
+                                        Modifier
+                                            .background(mainGreen.copy(alpha = 0.25f), likeBadgeShape)
+                                            .border(1.dp, mainGreen, likeBadgeShape)
+                                    } else {
+                                        Modifier
+                                            .background(Color(0xFF1A1A1A), likeBadgeShape)
+                                            .border(1.dp, Color.White.copy(alpha = 0.4f), likeBadgeShape)
+                                    }
+                                )
+                                .pointerInput(diaryId) {
+                                    detectTapGestures(
+                                        onTap = {
+                                            val id = diaryId ?: return@detectTapGestures
+                                            val previousIsLiked = isLiked
+                                            val previousLikeCount = likeCount
+                                            isLiked = !isLiked
+                                            likeCount = if (!previousIsLiked) {
+                                                likeCount + 1
+                                            } else {
+                                                (likeCount - 1).coerceAtLeast(0)
+                                            }
+                                            coroutineScope.launch {
+                                                repo.toggleLike(id).fold(
+                                                    onSuccess = { response ->
+                                                        isLiked = response.isLiked
+                                                    },
+                                                    onFailure = {
+                                                        isLiked = previousIsLiked
+                                                        likeCount = previousLikeCount
+                                                    }
+                                                )
+                                            }
+                                        },
+                                        onLongPress = {
+                                            diaryId?.let { likesDiaryId = it }
+                                        }
+                                    )
+                                }
+                                .padding(horizontal = 10.dp, vertical = 6.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Favorite,
+                                contentDescription = "좋아요",
+                                tint = if (isLiked) mainGreen else Color.White,
+                                modifier = Modifier.size(14.dp)
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(
+                                text = likeCount.toString(),
+                                fontFamily = PaperlogyFontFamily,
+                                fontWeight = FontWeight.Medium,
+                                fontSize = 12.sp,
+                                // color = if (isLiked) mainGreen else Color.White
+                                color = Color.White
+                            )
+                        }
+
+                        Image(
+                            painter = painterResource(
+                                id = if (isStored) R.drawable.is_stored else R.drawable.is_not_stored
+                            ),
+                            contentDescription = if (isStored) "보관됨" else "보관하기",
+                            modifier = Modifier
+                                .size(24.dp)
+                                .clickable {
+                                    val id = diaryId ?: return@clickable
+                                    val previousIsStored = isStored
+                                    isStored = !isStored
+                                    coroutineScope.launch {
+                                        repo.toggleStore(id).fold(
+                                            onSuccess = { response ->
+                                                isStored = response.isStored
+                                            },
+                                            onFailure = {
+                                                isStored = previousIsStored
+                                            }
+                                        )
+                                    }
+                                }
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(5.dp))
+            } else {
+                Spacer(modifier = Modifier.height(6.dp))
+            }
 
             Column(
                 modifier = Modifier
@@ -341,22 +490,18 @@ fun DiaryDetailScreen(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Box(
-                    modifier = Modifier.size(250.dp, 150.dp)
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
                 ) {
-//                    YouTubePlayerBox(
-//                        diary = diary,
-//                        startSeconds = startSeconds.toFloat(),
-//                        durationSeconds = duringSeconds.toFloat()
-//                    )
                     YouTubePlayerBox(
                         diary = diary,
                         startSeconds = startSeconds.toFloat(),
                         durationSeconds = duringSeconds.toFloat(),
-                        shouldLoop = true
+                        shouldLoop = true,
+                        showTrackInfo = false
                     )
                 }
-
-                Spacer(modifier = Modifier.height(16.dp))
 
                 AlbumDiaryBoxWithTimeBar(
                     track = SimpleTrack(
@@ -652,6 +797,42 @@ fun DiaryDetailScreen(
                 titleContentColor = Color.White,
                 textContentColor = Color.White
             )
+        }
+
+        if (likesDiaryId != null) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .zIndex(10f)
+            ) {
+                LikesModal(
+                    isLoading = isLoadingLikes,
+                    error = likesError,
+                    users = likesUsers,
+                    onDismiss = {
+                        likesDiaryId = null
+                        likesUsers = emptyList()
+                        likesError = null
+                    },
+                    onUserClick = { user ->
+                        likesDiaryId = null
+                        likesUsers = emptyList()
+                        likesError = null
+                        val encodedUsername = java.net.URLEncoder.encode(user.username, "UTF-8")
+                        val encodedTag = java.net.URLEncoder.encode(user.tag, "UTF-8")
+                        val encodedProfileImageUrl =
+                            java.net.URLEncoder.encode(user.profileImageUrl, "UTF-8")
+                        navController.navigate(
+                            "friend_profile" +
+                                "?userId=${user.userId}" +
+                                "&username=$encodedUsername" +
+                                "&tag=$encodedTag" +
+                                "&profileImageUrl=$encodedProfileImageUrl" +
+                                "&isMyPick=false"
+                        )
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/MainScreen/DiaryBox.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/MainScreen/DiaryBox.kt
@@ -29,7 +29,7 @@ fun DiaryBox(diary: Diary?) {
             text = "킬링파트 일기",
             fontFamily = PaperlogyFontFamily,
             fontWeight = FontWeight.Medium,
-            fontSize = 13.sp,
+            fontSize = 12.sp,
             color = Color(0xFFA4A4A6)
         )
 
@@ -40,7 +40,7 @@ fun DiaryBox(diary: Diary?) {
                 text = diaryContent,
                 fontFamily = PaperlogyFontFamily,
                 fontWeight = FontWeight.Normal,
-                fontSize = 14.sp,
+                fontSize = 11.sp,
                 color = Color.White
             )
         }

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/MainScreen/MusicListBox.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/MainScreen/MusicListBox.kt
@@ -185,8 +185,8 @@ fun MusicListBox(
                     state = listState,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 20.dp, vertical = 12.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
                 ) {
                     itemsIndexed(
                         displayList,

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/MainScreen/MusicListOne.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/MainScreen/MusicListOne.kt
@@ -54,34 +54,34 @@ fun MusicListOne(
             .scale(dragScale)
             .clickable(onClick = onClick)
             .background(color = rowBackground, shape = RoundedCornerShape(8.dp))
-            .padding(10.dp),
+            .padding(horizontal = 8.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         if (showDragHandle) {
             Image(
                 painter = painterResource(id = R.drawable.play_order_btn),
                 contentDescription = "순서 변경",
-                modifier = Modifier.size(16.dp).then(dragHandleModifier)
+                modifier = Modifier.size(14.dp).then(dragHandleModifier)
             )
-            Spacer(modifier = Modifier.width(24.dp))
+            Spacer(modifier = Modifier.width(16.dp))
         }
         AsyncImage(
             model = imageUrl,
             contentDescription = "앨범 표지",
-            modifier = Modifier.size(52.dp)
-                .background(color = Color.Transparent, shape = RoundedCornerShape(8.dp))
+            modifier = Modifier.size(40.dp)
+                .background(color = Color.Transparent, shape = RoundedCornerShape(6.dp))
         )
-        Spacer(modifier = Modifier.width(12.dp))
+        Spacer(modifier = Modifier.width(10.dp))
         Column (
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            verticalArrangement = Arrangement.spacedBy(4.dp)
         ){
             ScrollableText(
                 text = musicTitle,
                 modifier = Modifier.fillMaxWidth(),
                 fontFamily = PaperlogyFontFamily,
                 fontWeight = FontWeight.Normal,
-                fontSize = 14.sp,
+                fontSize = 12.sp,
                 color = Color.White
             )
             ScrollableText(
@@ -89,7 +89,7 @@ fun MusicListOne(
                 modifier = Modifier.fillMaxWidth(),
                 fontFamily = PaperlogyFontFamily,
                 fontWeight = FontWeight.Light,
-                fontSize = 10.sp,
+                fontSize = 9.sp,
                 color = Color.White
             )
         }
@@ -97,7 +97,7 @@ fun MusicListOne(
             androidx.compose.foundation.Image(
                 painter = painterResource(id = R.drawable.music_note_yellow),
                 contentDescription = "재생 중",
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier.size(16.dp)
             )
         }
     }

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/MainScreen/NextSongList.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/MainScreen/NextSongList.kt
@@ -46,7 +46,7 @@ fun NextSongList(
     ) {
         Text(
             text = label,
-            fontSize = 14.sp,
+            fontSize = 12.sp,
             fontFamily = PaperlogyFontFamily,
             fontWeight = FontWeight.Light,
             color = mainGreen
@@ -56,7 +56,7 @@ fun NextSongList(
 
         Text(
             text = title ?: "",
-            fontSize = 14.sp,
+            fontSize = 12.sp,
             fontFamily = PaperlogyFontFamily,
             fontWeight = FontWeight.Light,
             color = Color.White,
@@ -70,7 +70,7 @@ fun NextSongList(
         if (expanded) {
             Text(
                 text = if (isEditMode) "완료" else "편집",
-                fontSize = 14.sp,
+                fontSize = 12.sp,
                 fontFamily = PaperlogyFontFamily,
                 fontWeight = FontWeight.Light,
                 color = mainGreen,

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/MainScreen/YouTubePlayerBox.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/MainScreen/YouTubePlayerBox.kt
@@ -35,7 +35,8 @@ fun YouTubePlayerBox(
     onVideoReady: () -> Unit = {},
     isPlayingState: Boolean? = null,
     onVideoEnd: () -> Unit = {},
-    shouldLoop: Boolean = false
+    shouldLoop: Boolean = false,
+    showTrackInfo: Boolean = true
 ) {
     val context = LocalContext.current
     
@@ -217,35 +218,37 @@ fun YouTubePlayerBox(
                 }
             }
             
-            Spacer(modifier = Modifier.height(24.dp))
+            if (showTrackInfo) {
+                Spacer(modifier = Modifier.height(10.dp))
 
-            diary.musicTitle?.let { title ->
-                ScrollableText(
-                    text = title,
-                    modifier = Modifier.fillMaxWidth(),
-                    fontFamily = PaperlogyFontFamily,
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 18.sp,
-                    color = Color.White,
-                    centerAlign = true
-                )
+                diary.musicTitle?.let { title ->
+                    ScrollableText(
+                        text = title,
+                        modifier = Modifier.fillMaxWidth(),
+                        fontFamily = PaperlogyFontFamily,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 14.sp,
+                        color = Color.White,
+                        centerAlign = true
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                diary.artist?.let { artist ->
+                    ScrollableText(
+                        text = artist,
+                        modifier = Modifier.fillMaxWidth(),
+                        fontFamily = PaperlogyFontFamily,
+                        fontWeight = FontWeight.Light,
+                        fontSize = 12.sp,
+                        color = Color.White,
+                        centerAlign = true
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
             }
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            diary.artist?.let { artist ->
-                ScrollableText(
-                    text = artist,
-                    modifier = Modifier.fillMaxWidth(),
-                    fontFamily = PaperlogyFontFamily,
-                    fontWeight = FontWeight.Light,
-                    fontSize = 16.sp,
-                    color = Color.White,
-                    centerAlign = true
-                )
-            }
-
-            Spacer(modifier = Modifier.height(20.dp))
 
         }
     }

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/SocialScreen/FeedRunMusicBox.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/SocialScreen/FeedRunMusicBox.kt
@@ -300,12 +300,12 @@ fun FeedRunMusicBox(
                                     modifier = Modifier.fillMaxWidth(),
                                     fontFamily = PaperlogyFontFamily,
                                     fontWeight = FontWeight.Bold,
-                                    fontSize = 17.sp,
+                                    fontSize = 14.sp,
                                     color = Color.White
                                 )
                             }
 
-                            Spacer(modifier = Modifier.height(8.dp))
+                            Spacer(modifier = Modifier.height(4.dp))
 
                             diary.artist?.let { artist ->
                                 ScrollableText(
@@ -313,24 +313,24 @@ fun FeedRunMusicBox(
                                     modifier = Modifier.fillMaxWidth(),
                                     fontFamily = PaperlogyFontFamily,
                                     fontWeight = FontWeight.Light,
-                                    fontSize = 14.sp,
+                                    fontSize = 11.sp,
                                     color = Color.White
                                 )
                             }
                         }
-                        Spacer(modifier = Modifier.width(12.dp))
+                        Spacer(modifier = Modifier.width(8.dp))
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(10.dp)
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
                             Row(
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.Center,
                                 modifier = Modifier
-                                    .size(49.dp, 24.dp)
+                                    .size(40.dp, 20.dp)
                                     .background(
                                         color = if (isLiked) mainGreen else Color(0xFF2C2C2C),
-                                        RoundedCornerShape(8.dp)
+                                        RoundedCornerShape(6.dp)
                                     )
                                     .pointerInput(Unit) {
                                         detectTapGestures(
@@ -348,14 +348,14 @@ fun FeedRunMusicBox(
                                     imageVector = Icons.Filled.Favorite,
                                     contentDescription = "좋아요",
                                     tint = if (isLiked) Color.Black else mainGreen,
-                                    modifier = Modifier.size(16.dp)
+                                    modifier = Modifier.size(12.dp)
                                 )
-                                Spacer(modifier = Modifier.width(4.dp))
+                                Spacer(modifier = Modifier.width(3.dp))
                                 Text(
                                     text = likeCount.toString(),
                                     fontFamily = PaperlogyFontFamily,
                                     fontWeight = FontWeight.Medium,
-                                    fontSize = 12.sp,
+                                    fontSize = 10.sp,
                                     color = if (isLiked) Color.Black else Color.White
                                 )
                             }
@@ -365,7 +365,7 @@ fun FeedRunMusicBox(
                                 ),
                                 contentDescription = if (isStored) "보관됨" else "보관하기",
                                 modifier = Modifier
-                                    .size(24.dp)
+                                    .size(20.dp)
                                     .clickable {
                                         onStoreClick?.invoke()
                                     }
@@ -389,7 +389,8 @@ fun FeedRunMusicBox(
                                 isPlayingState = null,
                                 onVideoEnd = {
                                     onVideoEnd?.invoke()
-                                }
+                                },
+                                showTrackInfo = false
                             )
                         } else {
                             Box(
@@ -399,10 +400,10 @@ fun FeedRunMusicBox(
                                     .background(Color.Black.copy(alpha = 0.3f))
                             )
                         }
-                        Spacer(modifier = Modifier.height(20.dp))
+                        Spacer(modifier = Modifier.height(8.dp))
                     }
 
-                    Spacer(modifier = Modifier.height(18.dp))
+                    Spacer(modifier = Modifier.height(6.dp))
 
                     Column(
                         modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/SocialScreen/FriendProfileScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/SocialScreen/FriendProfileScreen.kt
@@ -254,18 +254,18 @@ fun FriendProfileScreen(
                                                             text = username.ifEmpty { "사용자" },
                                                             fontFamily = PaperlogyFontFamily,
                                                             fontWeight = FontWeight.W400,
-                                                            fontSize = 14.sp,
+                                                            fontSize = 12.sp,
                                                             color = mainGreen,
                                                             maxLines = 1,
                                                             overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
                                                         )
-                                                        Spacer(modifier = Modifier.height(6.dp))
+                                                        Spacer(modifier = Modifier.height(4.dp))
 
                                                         Text(
                                                             text = "@${tag.ifEmpty { "unknown" }}",
                                                             fontFamily = PaperlogyFontFamily,
                                                             fontWeight = FontWeight.W400,
-                                                            fontSize = 12.sp,
+                                                            fontSize = 10.sp,
                                                             color = mainGreen,
                                                             maxLines = 1,
                                                             overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
@@ -288,7 +288,7 @@ fun FriendProfileScreen(
                                                             text = "${state.diaries?.content?.size ?: 0}",
                                                             fontFamily = PaperlogyFontFamily,
                                                             fontWeight = FontWeight.W400,
-                                                            fontSize = 16.sp,
+                                                            fontSize = 13.sp,
                                                             color = mainGreen,
                                                             textAlign = androidx.compose.ui.text.style.TextAlign.Center
                                                         )
@@ -297,7 +297,7 @@ fun FriendProfileScreen(
                                                             text = "킬링파트",
                                                             fontFamily = PaperlogyFontFamily,
                                                             fontWeight = FontWeight.W400,
-                                                            fontSize = 10.sp,
+                                                            fontSize = 8.sp,
                                                             color = mainGreen,
                                                             textAlign = androidx.compose.ui.text.style.TextAlign.Center
                                                         )
@@ -320,7 +320,7 @@ fun FriendProfileScreen(
                                                             text = "${state.fansCount}",
                                                             fontFamily = PaperlogyFontFamily,
                                                             fontWeight = FontWeight.W400,
-                                                            fontSize = 16.sp,
+                                                            fontSize = 13.sp,
                                                             color = mainGreen,
                                                             textAlign = androidx.compose.ui.text.style.TextAlign.Center
                                                         )
@@ -329,7 +329,7 @@ fun FriendProfileScreen(
                                                             text = "팬덤",
                                                             fontFamily = PaperlogyFontFamily,
                                                             fontWeight = FontWeight.W400,
-                                                            fontSize = 10.sp,
+                                                            fontSize = 8.sp,
                                                             color = mainGreen,
                                                             textAlign = androidx.compose.ui.text.style.TextAlign.Center
                                                         )
@@ -352,7 +352,7 @@ fun FriendProfileScreen(
                                                             text = "${state.picksCount}",
                                                             fontFamily = PaperlogyFontFamily,
                                                             fontWeight = FontWeight.W400,
-                                                            fontSize = 16.sp,
+                                                            fontSize = 13.sp,
                                                             color = mainGreen,
                                                             textAlign = androidx.compose.ui.text.style.TextAlign.Center
                                                         )
@@ -362,7 +362,7 @@ fun FriendProfileScreen(
                                                             text = "PICKS",
                                                             fontFamily = PaperlogyFontFamily,
                                                             fontWeight = FontWeight.W400,
-                                                            fontSize = 10.sp,
+                                                            fontSize = 8.sp,
                                                             color = mainGreen,
                                                             textAlign = androidx.compose.ui.text.style.TextAlign.Center
                                                         )

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/SocialScreen/FriendProfileScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/SocialScreen/FriendProfileScreen.kt
@@ -383,9 +383,9 @@ fun FriendProfileScreen(
                                                         .height(32.dp)
                                                         .background(
                                                             color = if (currentIsMyPick) Color(
-                                                                0xFFCEFF43
-                                                            ) else Color(
                                                                 0xFF262626
+                                                            ) else Color(
+                                                                0xFFCEFF43
                                                             ),
                                                             shape = RoundedCornerShape(10.dp)
                                                         )
@@ -480,24 +480,13 @@ fun FriendProfileScreen(
                                                                 }
                                                             }
                                                         }
-                                                        .then(
-                                                            if (currentIsMyPick) {
-                                                                Modifier.border(
-                                                                    1.dp,
-                                                                    mainGreen,
-                                                                    RoundedCornerShape(10.dp)
-                                                                )
-                                                            } else {
-                                                                Modifier
-                                                            }
-                                                        ),
-                                                    contentAlignment = Alignment.Center
+                                                    , contentAlignment = Alignment.Center
                                                 ) {
                                                     Text(
                                                         text = if (currentIsMyPick) "나의 PICK!" else "나의 픽으로 추가",
                                                         color = if (currentIsMyPick) Color(
-                                                            0xFF000000
-                                                        ) else Color(0xFFCEFF43),
+                                                            0xFFCEFF43
+                                                        ) else Color(0xFF000000),
                                                         fontFamily = PaperlogyFontFamily,
                                                         fontSize = 10.sp,
                                                         fontWeight = FontWeight.W400

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/SocialScreen/FriendScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/SocialScreen/FriendScreen.kt
@@ -221,7 +221,7 @@ fun FriendScreen(
                 text = "나의 픽 ",
                 fontFamily = PaperlogyFontFamily,
                 fontWeight = if (selectedTab == FriendTab.PICKS) FontWeight.Medium else FontWeight.Light,
-                fontSize = 12.sp,
+                fontSize = 10.sp,
                 color = if (selectedTab == FriendTab.PICKS) Color.White else Color(0xFFA4A4A6),
                 modifier = Modifier.clickable { 
                     selectedTab = FriendTab.PICKS
@@ -235,7 +235,7 @@ fun FriendScreen(
                     }}",
                 fontFamily = PaperlogyFontFamily,
                 fontWeight = if (selectedTab == FriendTab.PICKS) FontWeight.Medium else FontWeight.Light,
-                fontSize = 12.sp,
+                fontSize = 10.sp,
                 color = if (selectedTab == FriendTab.PICKS) Color(0xFFCEFF43) else Color(0xFFA4A4A6),
                 modifier = Modifier.clickable { 
                     selectedTab = FriendTab.PICKS
@@ -249,7 +249,7 @@ fun FriendScreen(
                 text = "나의 팬덤 ",
                 fontFamily = PaperlogyFontFamily,
                 fontWeight = if (selectedTab == FriendTab.FANS) FontWeight.Medium else FontWeight.Light,
-                fontSize = 12.sp,
+                fontSize = 10.sp,
                 color = if (selectedTab == FriendTab.FANS) Color.White else Color(0xFFA4A4A6),
                 modifier = Modifier.clickable { 
                     selectedTab = FriendTab.FANS
@@ -263,7 +263,7 @@ fun FriendScreen(
                 }}",
                 fontFamily = PaperlogyFontFamily,
                 fontWeight = if (selectedTab == FriendTab.FANS) FontWeight.Medium else FontWeight.Light,
-                fontSize = 12.sp,
+                fontSize = 10.sp,
                 color = if (selectedTab == FriendTab.FANS) Color(0xFFCEFF43) else Color(0xFFA4A4A6),
                 modifier = Modifier.clickable { 
                     selectedTab = FriendTab.FANS
@@ -322,7 +322,7 @@ fun FriendScreen(
                             .fillMaxSize()
                             .weight(1f)
                             .padding(bottom = 10.dp),
-                        verticalArrangement = Arrangement.spacedBy(10.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         items(friends) { user ->
 
@@ -378,7 +378,6 @@ fun FriendItemCard(
                 shape = RoundedCornerShape(12.dp)
             )
             .padding(10.dp)
-            .padding(end=12.dp)
             .clickable {
                 // 픽/팬덤 리스트에서 진입한 경우: 내 프로필이든 친구 프로필이든 friend_profile + 뒤로가기만 표시
                 if (fromPickFandomList) {
@@ -423,7 +422,7 @@ fun FriendItemCard(
             // 프로필 이미지
             Box(
                 modifier = Modifier
-                    .size(50.dp)
+                    .size(40.dp)
                     .clip(CircleShape)
                     .border(2.dp, mainGreen, CircleShape)
             ) {
@@ -444,7 +443,7 @@ fun FriendItemCard(
                         text = user.username,
                         fontFamily = PaperlogyFontFamily,
                         fontWeight = FontWeight.Medium,
-                        fontSize = 12.sp,
+                        fontSize = 11.sp,
                         color = Color.White
                     )
                     // 팬덤 탭에서만: 나를 팔로우한 사람 중 내가 이미 픽한 경우
@@ -453,7 +452,7 @@ fun FriendItemCard(
                             text = "나의 픽",
                             fontFamily = PaperlogyFontFamily,
                             fontWeight = FontWeight.Medium,
-                            fontSize = 10.sp,
+                            fontSize = 11.sp,
                             color = mainGreen
                         )
                     }
@@ -463,7 +462,7 @@ fun FriendItemCard(
                     text = "@${user.tag}",
                     fontFamily = PaperlogyFontFamily,
                     fontWeight = FontWeight.Light,
-                    fontSize = 10.sp,
+                    fontSize = 9.sp,
                     color = Color(0xFFFFFFFF)
                 )
             }


### PR DESCRIPTION
# 변경점 👍
- 세부적인 ui 수치들을 조정하였습니다.
  - 대체로 큰 사이즈의 폰트들을 줄이는 작업들을 진행하였습니다.
- 다이어리 카드 좋아요 토글 강화
  - 좋아요 목록을 확인할 수 있다는 사실을 소수의 유저들만 알고 있어, 이 부분을 개선하기 위해
  - 좋아요 영역 보더를 추가하고, 내가 좋아요한 다이어리의 좋아요 표시 부분은 형광색으로 달리 표시합니다.
 - 친구 및 다른 사람 다이어리 조회 시 좋아요 및 저장 버튼 추가
   - 기존에는 세부 다이어리에서 좋아요 및 저장을 할 수 있는 방법이 없었습니다. 
   - 이를 보완하기 위해 우상단 빈 자리에 좋아요 버튼 및 저장 버튼을 추가합니다.
 - 나의 pick 추가 버튼 색 반전
   - 기존 : `나의 픽으로 추가` 버튼이 회색이고 추가가 된 후, `나의 pick! `버튼이 형광초록색 이었습니다. 
   - 하지만 형광 초록색이 뭔가 버튼을 안 누른 느낌이라 한 번 더 누르게 된다는 다수의 피드백이 있었습니다.
   - 이를 반영하여 나의 픽으로 되어있지 않은 상태에서 나의 픽으로 추가하는 버튼을 네온색으로 변경합니다.

## 스크린샷
<img width="222" height="515" alt="image" src="https://github.com/user-attachments/assets/04c48fde-65be-4fa3-ae58-5ddaf387a2ca" />
<img width="215" height="508" alt="image" src="https://github.com/user-attachments/assets/05a7054c-ce9d-4e0d-900e-e2be9061ff74" />

