### PR TITLE
feat: 구간자르기 리뉴얼 적용 및 장르 필드 추가를 위한 iTunes api로 전환

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.killingpart.killingpoint"
         minSdk = 29
         targetSdk = 36
-        versionCode = 44
-        versionName = "2.3.5"
+        versionCode = 45
+        versionName = "2.3.6"
 
         buildConfigField("String", "AMPLITUDE_API_KEY", "\"fcb84a98b48f87f85e7112a1587976fd\"")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/killingpart/killingpoint/data/itunes/ItunesModels.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/data/itunes/ItunesModels.kt
@@ -1,0 +1,19 @@
+package com.killingpart.killingpoint.data.itunes
+
+/** iTunes Search API (https://itunes.apple.com/search) 응답 */
+data class ItunesSearchResponse(
+    val resultCount: Int = 0,
+    val results: List<ItunesTrackItem> = emptyList()
+)
+
+data class ItunesTrackItem(
+    val trackId: Long? = null,
+    val trackName: String? = null,
+    val artistName: String? = null,
+    val artistId: Long? = null,
+    val collectionId: Long? = null,
+    val collectionName: String? = null,
+    val artworkUrl100: String? = null,
+    val primaryGenreName: String? = null,
+    val trackTimeMillis: Long? = null
+)

--- a/app/src/main/java/com/killingpart/killingpoint/data/model/CreateDiaryRequest.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/data/model/CreateDiaryRequest.kt
@@ -11,11 +11,15 @@ data class CreateDiaryRequest(
     val start: String,
     val end: String,
     val totalDuration: Int, // YouTube 비디오 전체 길이 (초 단위)
-    // 장르 추천 알고리즘용 (iTunes Search API 제공). 값이 없으면 null → 직렬화 시 생략
-    val sourceType: String? = null,
-    val trackId: Long? = null,
-    val artistId: Long? = null,
-    val primaryGenreName: String? = null
+    // 추천 기능용 음악 메타데이터 (iTunes). 값 없으면 null → 직렬화 시 생략(수정 시 기존값 보존)
+    val musicMetadata: MusicMetadata? = null
+)
+
+data class MusicMetadata(
+    val sourceType: String = "ITUNES",   // 현재 ITUNES 외 sourceType은 백엔드에서 건너뜀
+    val trackId: String? = null,         // 음원 id
+    val artistId: String? = null,        // 아티스트 id
+    val primaryGenreName: String? = null // iTunes 검색 결과 대표 장르
 )
 
 

--- a/app/src/main/java/com/killingpart/killingpoint/data/model/CreateDiaryRequest.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/data/model/CreateDiaryRequest.kt
@@ -10,7 +10,12 @@ data class CreateDiaryRequest(
     val duration: String,
     val start: String,
     val end: String,
-    val totalDuration: Int // YouTube 비디오 전체 길이 (초 단위)
+    val totalDuration: Int, // YouTube 비디오 전체 길이 (초 단위)
+    // 장르 추천 알고리즘용 (iTunes Search API 제공). 값이 없으면 null → 직렬화 시 생략
+    val sourceType: String? = null,
+    val trackId: Long? = null,
+    val artistId: Long? = null,
+    val primaryGenreName: String? = null
 )
 
 

--- a/app/src/main/java/com/killingpart/killingpoint/data/model/FeedDiary.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/data/model/FeedDiary.kt
@@ -31,7 +31,12 @@ data class FeedDiary(
     val userId: Long,
     val username: String,
     val tag: String,
-    val profileImageUrl: String
+    val profileImageUrl: String,
+    // GET /api/diaries/random 추천 항목 (장르 추천 알고리즘). 일반 항목엔 없음
+    @SerializedName("isRecommended")
+    val isRecommended: Boolean = false,
+    @SerializedName("recommendationReason")
+    val recommendationReason: String? = null // 예: "GENRE_MATCH"
 ) {
     val toDiary: Diary
         get() = Diary(

--- a/app/src/main/java/com/killingpart/killingpoint/data/remote/ItunesService.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/data/remote/ItunesService.kt
@@ -1,0 +1,19 @@
+package com.killingpart.killingpoint.data.remote
+
+import com.killingpart.killingpoint.data.itunes.ItunesSearchResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+/** iTunes Search API. baseUrl = https://itunes.apple.com/ */
+interface ItunesService {
+
+    @GET("search")
+    suspend fun searchTracks(
+        @Query("term") term: String,
+        @Query("media") media: String = "music",
+        @Query("entity") entity: String = "song",
+        @Query("country") country: String = "KR",
+        @Query("lang") lang: String = "ko_kr",
+        @Query("limit") limit: Int = 10
+    ): ItunesSearchResponse
+}

--- a/app/src/main/java/com/killingpart/killingpoint/data/repository/ItunesRepository.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/data/repository/ItunesRepository.kt
@@ -1,0 +1,58 @@
+package com.killingpart.killingpoint.data.repository
+
+import com.killingpart.killingpoint.data.itunes.ItunesSearchResponse
+import com.killingpart.killingpoint.data.remote.ItunesService
+import com.killingpart.killingpoint.data.spotify.SimpleTrack
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+/**
+ * 곡 정보 검색 = Apple iTunes Search API.
+ * 장르 추천 알고리즘용 필드(trackId / artistId / primaryGenreName)와 sourceType(ITUNES)을 함께 제공한다.
+ */
+class ItunesRepository(
+    private val service: ItunesService
+) {
+
+    suspend fun searchTracks(query: String, country: String = "KR", limit: Int = 10): List<SimpleTrack> =
+        withContext(Dispatchers.IO) {
+            if (query.isBlank()) return@withContext emptyList()
+            val res: ItunesSearchResponse = service.searchTracks(term = query, country = country, limit = limit)
+            res.results.mapNotNull { item ->
+                val title = item.trackName ?: return@mapNotNull null
+                SimpleTrack(
+                    id = item.trackId?.toString() ?: return@mapNotNull null,
+                    title = title,
+                    artist = item.artistName.orEmpty(),
+                    // 100x100 썸네일 URL을 고해상도로 치환
+                    albumImageUrl = item.artworkUrl100?.replace("100x100bb", "600x600bb"),
+                    albumId = item.collectionId?.toString().orEmpty(),
+                    trackId = item.trackId,
+                    artistId = item.artistId,
+                    primaryGenreName = item.primaryGenreName,
+                    sourceType = SOURCE_TYPE
+                )
+            }
+        }
+
+    companion object {
+        const val SOURCE_TYPE = "ITUNES"
+
+        fun create(): ItunesRepository {
+            val logging = HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.BASIC }
+            val client = OkHttpClient.Builder()
+                .addInterceptor(logging)
+                .build()
+            val retrofit = Retrofit.Builder()
+                .baseUrl("https://itunes.apple.com/")
+                .client(client)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+            return ItunesRepository(retrofit.create(ItunesService::class.java))
+        }
+    }
+}

--- a/app/src/main/java/com/killingpart/killingpoint/data/repository/ItunesRepository.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/data/repository/ItunesRepository.kt
@@ -31,8 +31,8 @@ class ItunesRepository(
                     // 100x100 썸네일 URL을 고해상도로 치환
                     albumImageUrl = item.artworkUrl100?.replace("100x100bb", "600x600bb"),
                     albumId = item.collectionId?.toString().orEmpty(),
-                    trackId = item.trackId,
-                    artistId = item.artistId,
+                    trackId = item.trackId?.toString(),
+                    artistId = item.artistId?.toString(),
                     primaryGenreName = item.primaryGenreName,
                     sourceType = SOURCE_TYPE
                 )

--- a/app/src/main/java/com/killingpart/killingpoint/data/spotify/SpotifyModels.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/data/spotify/SpotifyModels.kt
@@ -35,6 +35,11 @@ data class SimpleTrack(
     val title: String,
     val artist: String,
     val albumImageUrl: String?,
-    val albumId: String // Spotify 앨범 ID
+    val albumId: String, // 앨범 ID (iTunes collectionId)
+    // 장르 추천 알고리즘용 (iTunes Search API 제공 필드)
+    val trackId: Long? = null,
+    val artistId: Long? = null,
+    val primaryGenreName: String? = null,
+    val sourceType: String = "ITUNES"
 )
 

--- a/app/src/main/java/com/killingpart/killingpoint/data/spotify/SpotifyModels.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/data/spotify/SpotifyModels.kt
@@ -36,9 +36,9 @@ data class SimpleTrack(
     val artist: String,
     val albumImageUrl: String?,
     val albumId: String, // 앨범 ID (iTunes collectionId)
-    // 장르 추천 알고리즘용 (iTunes Search API 제공 필드)
-    val trackId: Long? = null,
-    val artistId: Long? = null,
+    // 장르 추천 알고리즘용 (iTunes Search API 제공 필드) — 요청은 문자열로 보냄
+    val trackId: String? = null,
+    val artistId: String? = null,
     val primaryGenreName: String? = null,
     val sourceType: String = "ITUNES"
 )

--- a/app/src/main/java/com/killingpart/killingpoint/navigation/NavGraph.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/navigation/NavGraph.kt
@@ -113,6 +113,10 @@ fun NavGraph(
                     "&image={image}" +
                     "&videoUrl={videoUrl}" +
                     "&totalDuration={totalDuration}" +
+                    "&sourceType={sourceType}" +
+                    "&trackId={trackId}" +
+                    "&artistId={artistId}" +
+                    "&primaryGenreName={primaryGenreName}" +
                     "&tutorial={tutorial}",
             arguments = listOf(
                 navArgument("title") { type = NavType.StringType; defaultValue = "" },
@@ -120,6 +124,10 @@ fun NavGraph(
                 navArgument("image") { type = NavType.StringType; defaultValue = "" },
                 navArgument("videoUrl") { type = NavType.StringType; defaultValue = "" },
                 navArgument("totalDuration") { type = NavType.StringType; defaultValue = "" },
+                navArgument("sourceType") { type = NavType.StringType; defaultValue = "ITUNES" },
+                navArgument("trackId") { type = NavType.StringType; defaultValue = "" },
+                navArgument("artistId") { type = NavType.StringType; defaultValue = "" },
+                navArgument("primaryGenreName") { type = NavType.StringType; defaultValue = "" },
                 navArgument("tutorial") { type = NavType.BoolType; defaultValue = false }
             )
         ) { backStackEntry ->
@@ -129,9 +137,20 @@ fun NavGraph(
             val videoUrl = URLDecoder.decode(backStackEntry.arguments?.getString("videoUrl").orEmpty(), "UTF-8")
             val totalDurationStr = backStackEntry.arguments?.getString("totalDuration") ?: ""
             val totalDuration = totalDurationStr.toIntOrNull() ?: 0
+            val sourceType = backStackEntry.arguments?.getString("sourceType").orEmpty().ifEmpty { "ITUNES" }
+            val trackId = backStackEntry.arguments?.getString("trackId").orEmpty().ifEmpty { null }
+            val artistId = backStackEntry.arguments?.getString("artistId").orEmpty().ifEmpty { null }
+            val primaryGenreName = URLDecoder.decode(backStackEntry.arguments?.getString("primaryGenreName").orEmpty(), "UTF-8").ifEmpty { null }
             val tutorial = backStackEntry.arguments?.getBoolean("tutorial") ?: false
 
-            SelectDurationScreen(navController, title, artist, image, videoUrl, totalDuration, tutorialMode = tutorial)
+            SelectDurationScreen(
+                navController, title, artist, image, videoUrl, totalDuration,
+                tutorialMode = tutorial,
+                sourceType = sourceType,
+                trackId = trackId,
+                artistId = artistId,
+                primaryGenreName = primaryGenreName
+            )
         }
 
         composable(
@@ -144,6 +163,10 @@ fun NavGraph(
                     "&end={end}" +
                     "&videoUrl={videoUrl}" +
                     "&totalDuration={totalDuration}" +
+                    "&sourceType={sourceType}" +
+                    "&trackId={trackId}" +
+                    "&artistId={artistId}" +
+                    "&primaryGenreName={primaryGenreName}" +
                     "&tutorial={tutorial}",
             arguments = listOf(
                 navArgument("title") { type = NavType.StringType; defaultValue = "" },
@@ -154,6 +177,10 @@ fun NavGraph(
                 navArgument("end") { type = NavType.StringType; defaultValue = "" },
                 navArgument("videoUrl") { type = NavType.StringType; defaultValue = "" },
                 navArgument("totalDuration") { type = NavType.StringType; defaultValue = "" },
+                navArgument("sourceType") { type = NavType.StringType; defaultValue = "ITUNES" },
+                navArgument("trackId") { type = NavType.StringType; defaultValue = "" },
+                navArgument("artistId") { type = NavType.StringType; defaultValue = "" },
+                navArgument("primaryGenreName") { type = NavType.StringType; defaultValue = "" },
                 navArgument("tutorial") { type = NavType.BoolType; defaultValue = false }
             )
         ) { backStackEntry ->
@@ -166,6 +193,10 @@ fun NavGraph(
             val videoUrl = URLDecoder.decode(backStackEntry.arguments?.getString("videoUrl").orEmpty(), "UTF-8")
             val totalDurationStr = backStackEntry.arguments?.getString("totalDuration") ?: ""
             val totalDuration = totalDurationStr.toIntOrNull() ?: 0
+            val sourceType = backStackEntry.arguments?.getString("sourceType").orEmpty().ifEmpty { "ITUNES" }
+            val trackId = backStackEntry.arguments?.getString("trackId").orEmpty().ifEmpty { null }
+            val artistId = backStackEntry.arguments?.getString("artistId").orEmpty().ifEmpty { null }
+            val primaryGenreName = URLDecoder.decode(backStackEntry.arguments?.getString("primaryGenreName").orEmpty(), "UTF-8").ifEmpty { null }
             val tutorial = backStackEntry.arguments?.getBoolean("tutorial") ?: false
 
             WriteDiaryScreen(
@@ -178,7 +209,11 @@ fun NavGraph(
                 end,
                 videoUrl,
                 totalDuration,
-                tutorialMode = tutorial
+                tutorialMode = tutorial,
+                sourceType = sourceType,
+                trackId = trackId,
+                artistId = artistId,
+                primaryGenreName = primaryGenreName
             )
         }
 

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/AddMusicScreen/AddMusicScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/AddMusicScreen/AddMusicScreen.kt
@@ -282,6 +282,10 @@ private fun TrackRowWithVideoSearch(
                             "&image=$encodedImage" +
                             "&videoUrl=$encodedVideoUrl" +
                             "&totalDuration=$totalDuration" +
+                            "&sourceType=${track.sourceType}" +
+                            "&trackId=${track.trackId ?: ""}" +
+                            "&artistId=${track.artistId ?: ""}" +
+                            "&primaryGenreName=${java.net.URLEncoder.encode(track.primaryGenreName ?: "", "UTF-8")}" +
                             "&tutorial=$tutorialArg"
                 )
             } catch (e: Exception) {
@@ -298,6 +302,10 @@ private fun TrackRowWithVideoSearch(
                             "&image=$encodedImage" +
                             "&videoUrl=" +
                             "&totalDuration=180" +
+                            "&sourceType=${track.sourceType}" +
+                            "&trackId=${track.trackId ?: ""}" +
+                            "&artistId=${track.artistId ?: ""}" +
+                            "&primaryGenreName=${java.net.URLEncoder.encode(track.primaryGenreName ?: "", "UTF-8")}" +
                             "&tutorial=$tutorialArg"
                 )
             } finally {

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/MainScreen/YouTubePlayerBox.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/MainScreen/YouTubePlayerBox.kt
@@ -24,19 +24,32 @@ import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.listeners.Abs
 import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.views.YouTubePlayerView
 import androidx.compose.runtime.DisposableEffect
 
+/** 온디맨드 seek+재생 명령. id 가 바뀔 때마다 실행됨 */
+data class PlayCommand(val id: Long, val seekTo: Float)
+
 /**
  * YouTube Player API를 사용한 백그라운드 재생 가능한 플레이어
  */
 @Composable
 fun YouTubePlayerBox(
-    diary: Diary?, 
-    startSeconds: Float, 
+    diary: Diary?,
+    startSeconds: Float,
     durationSeconds: Float = 0f,
     onVideoReady: () -> Unit = {},
     isPlayingState: Boolean? = null,
     onVideoEnd: () -> Unit = {},
     shouldLoop: Boolean = false,
-    showTrackInfo: Boolean = true
+    showTrackInfo: Boolean = true,
+    /** 현재 재생 위치(초)를 부모로 전달 */
+    onCurrentSecondChange: (Float) -> Unit = {},
+    /** 재생 상태(재생/정지)를 부모로 전달 */
+    onPlayingChange: (Boolean) -> Unit = {},
+    /** 온디맨드 seek+재생 (트랙 탭 / 좌핸들 탭 등) */
+    playCommand: PlayCommand? = null,
+    /** 지정 시 이 구간으로 루프 (2초 루프 등). null 이면 [startSeconds, endSeconds] 루프 */
+    loopOverride: ClosedFloatingPointRange<Float>? = null,
+    /** startSeconds 변경 시 자동 seek 여부. 구간 리사이즈 중 재생을 끊고 싶지 않으면 false */
+    seekOnStartChange: Boolean = true
 ) {
     val context = LocalContext.current
     
@@ -72,18 +85,51 @@ fun YouTubePlayerBox(
             }
             
             // startSeconds가 변경될 때 seekTo로 위치 이동 (디바운싱 적용)
-            LaunchedEffect(startSeconds) {
-                if (player != null) {
+            LaunchedEffect(startSeconds, seekOnStartChange) {
+                if (seekOnStartChange && player != null) {
                     // 500ms 디바운싱: 사용자가 슬라이더를 계속 움직이면 마지막 값만 적용
                     kotlinx.coroutines.delay(500)
                     player?.seekTo(startSeconds)
                 }
             }
 
+            // 현재 재생 위치 / 재생 상태 부모로 전달
+            LaunchedEffect(currentTime) { onCurrentSecondChange(currentTime) }
+            LaunchedEffect(isPlaying) { onPlayingChange(isPlaying) }
+
+            // 온디맨드 seek+재생 (트랙 탭 / 좌핸들 탭)
+            LaunchedEffect(playCommand) {
+                val cmd = playCommand ?: return@LaunchedEffect
+                player?.let {
+                    it.seekTo(cmd.seekTo)
+                    it.play()
+                }
+            }
+
+            // 루프 구간이 지정되면 해당 구간 시작으로 이동해 루프 시작
+            LaunchedEffect(loopOverride) {
+                val range = loopOverride ?: return@LaunchedEffect
+                player?.let {
+                    it.seekTo(range.start)
+                    it.play()
+                }
+            }
+
             val onVideoEndCallback = remember(onVideoEnd) { onVideoEnd }
             
-            LaunchedEffect(currentTime, endSeconds, startSeconds, durationSeconds, player, shouldLoop) {
-                if (isPlaying && player != null && endSeconds != null && durationSeconds > 0f && currentTime >= endSeconds) {
+            LaunchedEffect(currentTime, endSeconds, startSeconds, durationSeconds, player, shouldLoop, loopOverride) {
+                if (!isPlaying || player == null) return@LaunchedEffect
+
+                // 2초 루프 등 override 구간이 지정되면 해당 구간만 반복
+                if (loopOverride != null) {
+                    if (currentTime >= loopOverride.endInclusive) {
+                        player?.seekTo(loopOverride.start)
+                        player?.play()
+                    }
+                    return@LaunchedEffect
+                }
+
+                if (endSeconds != null && durationSeconds > 0f && currentTime >= endSeconds) {
                     if (shouldLoop) {
                         player?.seekTo(startSeconds)
                         player?.play()

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/KillingPartSelector.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/KillingPartSelector.kt
@@ -81,7 +81,7 @@ fun KillingPartSelector(
     totalDuration: Int,
     /** 첫 레이아웃 시 선택 구간 (다른 영상으로 바꿀 때 부모에서 넘김) */
     initialStartSec: Float = 0f,
-    initialDurationSec: Float = 10f,
+    initialDurationSec: Float = 20f,
     /** 현재 재생 위치(절대 초). 재생 인디케이터/채우기 표시용 */
     currentPlaySec: Float = 0f,
     isPlaying: Boolean = false,
@@ -298,7 +298,8 @@ fun KillingPartSelector(
                         val top = centerY - barH / 2f
 
                         val inSection = sec >= startSec - eps && sec <= endSec + eps
-                        val played = isPlaying && sec <= displayPlaySec + eps
+                        // 재생 인디케이터가 지나간(재생된) 구간 막대는 네온색으로
+                        val played = displayPlaySec > startSec - eps && sec <= displayPlaySec + eps
                         val color = when {
                             !inSection -> Color(0xFF454545)
                             played -> mainGreen
@@ -346,7 +347,7 @@ fun KillingPartSelector(
                 )
 
                 // 흰색 재생 인디케이터
-                if (isPlaying && displayPlaySec in startSec..endSec) {
+                if (displayPlaySec in startSec..endSec) {
                     val px = sx(displayPlaySec)
                     drawRoundRect(
                         color = Color.White,
@@ -366,8 +367,9 @@ fun KillingPartSelector(
                 pressed = pressedSide == HandleSide.LEFT,
                 modifier = Modifier
                     .offset {
+                        // 박스 컨테이너 안쪽: 핸들 왼쪽 끝이 구간 시작(박스 좌측)에 맞도록
                         IntOffset(
-                            (secToX(startSec) - handleWidthPx / 2f).roundToInt(),
+                            secToX(startSec).roundToInt(),
                             0
                         )
                     }
@@ -396,8 +398,9 @@ fun KillingPartSelector(
                 pressed = pressedSide == HandleSide.RIGHT,
                 modifier = Modifier
                     .offset {
+                        // 박스 컨테이너 안쪽: 핸들 오른쪽 끝이 구간 끝(박스 우측)에 맞도록
                         IntOffset(
-                            (secToX(endSec) - handleWidthPx / 2f).roundToInt(),
+                            (secToX(endSec) - handleWidthPx).roundToInt(),
                             0
                         )
                     }
@@ -483,6 +486,8 @@ fun KillingPartSelector(
             },
             onScrubEnd = {
                 commit(force = true)
+                // 미니맵으로 구간을 옮기면 새 구간 시작부터 다시 재생
+                latestOnSeek(startSec)
                 latestOnHandleAdjusted?.invoke(KillingPartHandle.SPECTRUM_BAR)
             }
         )

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/KillingPartSelector.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/KillingPartSelector.kt
@@ -105,7 +105,7 @@ fun KillingPartSelector(
     val trackHeight = 120.dp
     val boxHeight = 92.dp
     val handleWidth = 22.dp
-    val handleHeight = 92.dp
+    val handleHeight = 74.dp
     val handleCorner = 7.dp
     val boxCorner = 12.dp
     val edgeButtonSize = 34.dp
@@ -174,16 +174,27 @@ fun KillingPartSelector(
         }
     }
 
-    // 재생 인디케이터 스무딩 (onCurrentSecond 는 대략 1초 간격 → 선형 보간, seek/loop 점프는 snap)
-    val playAnim = remember { Animatable(0f) }
+    // 재생 인디케이터: 프레임 기반 1x 진행 + 권위값(currentPlaySec) 큰 점프만 보정
+    //  - onCurrentSecond 는 ~1초 간격(지터 有) → 매 프레임 실제 경과시간만큼 진행시켜 부드럽게
+    //  - seek/루프 등 0.75초 초과 점프만 즉시 반영(그 외 소소한 지터는 무시해 멈춤/역행 방지)
+    var displayPlaySec by remember { mutableStateOf(0f) }
     LaunchedEffect(currentPlaySec) {
-        if (abs(currentPlaySec - playAnim.value) > 1.2f) {
-            playAnim.snapTo(currentPlaySec)
-        } else {
-            playAnim.animateTo(currentPlaySec, tween(durationMillis = 1000, easing = LinearEasing))
+        if (abs(currentPlaySec - displayPlaySec) > 0.75f) {
+            displayPlaySec = currentPlaySec
         }
     }
-    val displayPlaySec = playAnim.value
+    LaunchedEffect(isPlaying) {
+        if (!isPlaying) return@LaunchedEffect
+        var last = 0L
+        while (true) {
+            withFrameNanos { now ->
+                if (last != 0L) {
+                    displayPlaySec += (now - last) / 1_000_000_000f
+                }
+                last = now
+            }
+        }
+    }
 
     fun applyResize(side: HandleSide, dxPx: Float) {
         val dSec = dxPx / pxPerSec
@@ -421,30 +432,13 @@ fun KillingPartSelector(
                     )
             )
 
-            // ---- -1s / +1s 원형 버튼 ----
-            EdgeStepButton(
-                label = "-1s",
-                size = edgeButtonSize,
-                modifier = Modifier
-                    .align(Alignment.CenterStart)
-                    .zIndex(11f),
-                onClick = { extendFront() }
-            )
-            EdgeStepButton(
-                label = "+1s",
-                size = edgeButtonSize,
-                modifier = Modifier
-                    .align(Alignment.CenterEnd)
-                    .zIndex(11f),
-                onClick = { extendBack() }
-            )
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(4.dp))
 
-        // ---- 핸들 시간 라벨 ----
-        Box(modifier = Modifier.fillMaxWidth().height(18.dp)) {
-            val labelHalfPx = with(density) { 38.dp.toPx() }
+        // ---- 핸들 시간 라벨 (핸들 위치 따라, 살짝 위로) ----
+        val labelHalfPx = with(density) { 38.dp.toPx() }
+        Box(modifier = Modifier.fillMaxWidth().height(16.dp)) {
             HandleTimeLabel(
                 text = formatTime(startSec),
                 modifier = Modifier.offset {
@@ -466,6 +460,39 @@ fun KillingPartSelector(
                         0
                     )
                 }
+            )
+        }
+
+        Spacer(modifier = Modifier.height(6.dp))
+
+        // ---- -1s / +1s 버튼: 각 시간 라벨 바로 아래(핸들 위치 따라) ----
+        val edgeButtonHalfPx = with(density) { edgeButtonSize.toPx() / 2f }
+        Box(modifier = Modifier.fillMaxWidth().height(edgeButtonSize)) {
+            EdgeStepButton(
+                label = "-1s",
+                size = edgeButtonSize,
+                modifier = Modifier.offset {
+                    IntOffset(
+                        (secToX(startSec) - edgeButtonHalfPx)
+                            .coerceIn(0f, (viewportWidthPx - edgeButtonHalfPx * 2f).coerceAtLeast(0f))
+                            .roundToInt(),
+                        0
+                    )
+                },
+                onClick = { extendFront() }
+            )
+            EdgeStepButton(
+                label = "+1s",
+                size = edgeButtonSize,
+                modifier = Modifier.offset {
+                    IntOffset(
+                        (secToX(endSec) - edgeButtonHalfPx)
+                            .coerceIn(0f, (viewportWidthPx - edgeButtonHalfPx * 2f).coerceAtLeast(0f))
+                            .roundToInt(),
+                        0
+                    )
+                },
+                onClick = { extendBack() }
             )
         }
 
@@ -573,12 +600,24 @@ private fun EdgeStepButton(
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
+    var pressed by remember { mutableStateOf(false) }
+    val alpha by animateFloatAsState(if (pressed) 0.5f else 1f, label = "stepBtnAlpha")
     Box(
         modifier = modifier
             .size(size)
+            .graphicsLayer { this.alpha = alpha }
             .clip(CircleShape)
             .background(mainGreen)
-            .pointerInput(Unit) { detectTapGestures { onClick() } },
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onPress = {
+                        pressed = true
+                        tryAwaitRelease()
+                        pressed = false
+                    },
+                    onTap = { onClick() }
+                )
+            },
         contentAlignment = Alignment.Center
     ) {
         Text(

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/KillingPartSelector.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/KillingPartSelector.kt
@@ -25,9 +25,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.RoundRect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
@@ -108,7 +112,7 @@ fun KillingPartSelector(
     val handleHeight = 74.dp
     val handleCorner = 7.dp
     val boxCorner = 12.dp
-    val edgeButtonSize = 34.dp
+    val edgeButtonSize = 32.dp
 
     val barWidth = 3.dp
     val barGap = 4.dp
@@ -327,45 +331,55 @@ fun KillingPartSelector(
                     sec += stepSec
                 }
 
-                // 루프 2초 밴드 하이라이트
-                if (loopSide != null) {
-                    val lx = sx(loopStartSec)
-                    val rx = sx(loopEndSec)
-                    val bH = with(density) { boxHeight.toPx() }
-                    drawRoundRect(
-                        color = mainGreen.copy(alpha = 0.28f),
-                        topLeft = Offset(lx, centerY - bH / 2f),
-                        size = Size((rx - lx).coerceAtLeast(0f), bH),
-                        cornerRadius = CornerRadius(
-                            with(density) { 6.dp.toPx() },
-                            with(density) { 6.dp.toPx() }
+                // 박스 지오메트리 (루프 밴드/테두리/인디케이터 공용)
+                val boxLeft = sx(startSec)
+                val boxRight = sx(endSec)
+                val bH = with(density) { boxHeight.toPx() }
+                val boxTop = centerY - bH / 2f
+                val strokePx = with(density) { 2.dp.toPx() }
+                val rad = with(density) { boxCorner.toPx() }
+                val boxPath = Path().apply {
+                    addRoundRect(
+                        RoundRect(
+                            rect = Rect(boxLeft, boxTop, boxRight, boxTop + bH),
+                            cornerRadius = CornerRadius(rad, rad)
                         )
                     )
                 }
 
+                // 루프 2초 밴드 하이라이트 (박스 컨테이너 라운드에 맞춰 클립)
+                if (loopSide != null) {
+                    val lx = sx(loopStartSec)
+                    val rx = sx(loopEndSec)
+                    clipPath(boxPath) {
+                        drawRect(
+                            color = mainGreen.copy(alpha = 0.28f),
+                            topLeft = Offset(lx, boxTop),
+                            size = Size((rx - lx).coerceAtLeast(0f), bH)
+                        )
+                    }
+                }
+
                 // 선택 구간 네온 박스 테두리
-                val boxLeft = sx(startSec)
-                val boxRight = sx(endSec)
-                val bH = with(density) { boxHeight.toPx() }
-                val strokePx = with(density) { 2.dp.toPx() }
-                val rad = with(density) { boxCorner.toPx() }
                 drawRoundRect(
                     color = mainGreen,
-                    topLeft = Offset(boxLeft, centerY - bH / 2f),
+                    topLeft = Offset(boxLeft, boxTop),
                     size = Size((boxRight - boxLeft).coerceAtLeast(0f), bH),
                     cornerRadius = CornerRadius(rad, rad),
                     style = Stroke(width = strokePx)
                 )
 
-                // 흰색 재생 인디케이터
+                // 흰색 재생 인디케이터: 박스 컨테이너 path로 클립 → 라운드 코너 근처에선
+                //  자동으로 짧아지고 가운데선 박스 높이를 꽉 채움 (고정 높이 아님)
                 if (displayPlaySec in startSec..endSec) {
                     val px = sx(displayPlaySec)
-                    drawRoundRect(
-                        color = Color.White,
-                        topLeft = Offset(px - strokePx / 2f, centerY - bH / 2f),
-                        size = Size(strokePx, bH),
-                        cornerRadius = CornerRadius(strokePx, strokePx)
-                    )
+                    clipPath(boxPath) {
+                        drawRect(
+                            color = Color.White,
+                            topLeft = Offset(px - strokePx / 2f, boxTop),
+                            size = Size(strokePx, bH)
+                        )
+                    }
                 }
             }
 
@@ -465,33 +479,18 @@ fun KillingPartSelector(
 
         Spacer(modifier = Modifier.height(6.dp))
 
-        // ---- -1s / +1s 버튼: 각 시간 라벨 바로 아래(핸들 위치 따라) ----
-        val edgeButtonHalfPx = with(density) { edgeButtonSize.toPx() / 2f }
+        // ---- -1s / +1s 버튼: 양쪽 끝 고정 (초 텍스트는 핸들 따라 이동) ----
         Box(modifier = Modifier.fillMaxWidth().height(edgeButtonSize)) {
             EdgeStepButton(
                 label = "-1s",
                 size = edgeButtonSize,
-                modifier = Modifier.offset {
-                    IntOffset(
-                        (secToX(startSec) - edgeButtonHalfPx)
-                            .coerceIn(0f, (viewportWidthPx - edgeButtonHalfPx * 2f).coerceAtLeast(0f))
-                            .roundToInt(),
-                        0
-                    )
-                },
+                modifier = Modifier.align(Alignment.CenterStart),
                 onClick = { extendFront() }
             )
             EdgeStepButton(
                 label = "+1s",
                 size = edgeButtonSize,
-                modifier = Modifier.offset {
-                    IntOffset(
-                        (secToX(endSec) - edgeButtonHalfPx)
-                            .coerceIn(0f, (viewportWidthPx - edgeButtonHalfPx * 2f).coerceAtLeast(0f))
-                            .roundToInt(),
-                        0
-                    )
-                },
+                modifier = Modifier.align(Alignment.CenterEnd),
                 onClick = { extendBack() }
             )
         }
@@ -587,7 +586,7 @@ private fun HandleTimeLabel(text: String, modifier: Modifier = Modifier) {
             text = text,
             fontFamily = PaperlogyFontFamily,
             fontWeight = FontWeight.W400,
-            fontSize = 13.sp,
+            fontSize = 11.sp,
             color = Color.White
         )
     }

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/KillingPartSelector.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/KillingPartSelector.kt
@@ -1,41 +1,53 @@
 package com.killingpart.killingpoint.ui.screen.WriteDiaryScreen
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
-import com.killingpart.killingpoint.R
 import com.killingpart.killingpoint.ui.theme.PaperlogyFontFamily
 import com.killingpart.killingpoint.ui.theme.mainGreen
-import kotlin.math.PI
-import kotlin.math.sin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.math.abs
 import kotlin.math.roundToInt
+import kotlin.math.sin
 
 fun formatTime(seconds: Float): String {
     val totalSeconds = seconds.toInt().coerceAtLeast(0)
@@ -44,17 +56,25 @@ fun formatTime(seconds: Float): String {
     return String.format("%02d:%02d", minutes, secs)
 }
 
-/** 모든 구성 요소를 하나의 시간 좌표계로 통일한다
- * 타임라인 바 : 절대 위치(px)
- * 핸들 : 화면 위치(px)
- * 스크롤 : 절대 이동량(px)
- * 시간 : (절대 px + 화면 px) / pxPerSecond
+/** 구간자르기 개선안(PM 스펙) 구현
  *
- * 핸들은 화면에 고정된 UI 요소
- * 스크롤 + handle(px)를 합쳐야 핸들이 가리키는 절대 시간을 알 수 있음
- * 바의 highlight는 '절대 시간' 기준
- * barCenterSec, startSec, endSec 모두 절대 시간 통일
+ * 좌표계: 모든 요소를 '절대 초(sec)' 기준으로 통일
+ *  - startSec / endSec : 선택 구간(절대 초)
+ *  - viewCenterSec     : 뷰포트 가로 중앙에 오는 절대 초 (Animatable)
+ *  - secToX(sec)       : viewportWidth/2 + (sec - viewCenterSec) * pxPerSec
+ *
+ * 인터랙션
+ *  - 핸들 드래그: 구간 리사이즈. 뗀 후 0.4초 tween 으로 구간 중앙이 뷰 중앙으로 복귀
+ *  - 좌측 핸들 탭: 구간 처음부터 재생(onSeek)
+ *  - 핸들 0.5초 롱프레스: 핸들 옆 2초 루프 활성(onLoopChange), 떼거나 움직이면 해제
+ *  - 트랙 탭: 그 지점부터 재생(onSeek)
+ *  - -1s/+1s: 구간 앞/뒤 1초 확장(재생 유지), 조정 후 중앙 복귀
+ *
+ * 재생 표시
+ *  - currentPlaySec 위치에 흰색 인디케이터, 재생된 구간 막대는 네온색으로 채워짐
  */
+
+private enum class HandleSide { LEFT, RIGHT }
 
 @Composable
 fun KillingPartSelector(
@@ -62,414 +82,410 @@ fun KillingPartSelector(
     /** 첫 레이아웃 시 선택 구간 (다른 영상으로 바꿀 때 부모에서 넘김) */
     initialStartSec: Float = 0f,
     initialDurationSec: Float = 10f,
+    /** 현재 재생 위치(절대 초). 재생 인디케이터/채우기 표시용 */
+    currentPlaySec: Float = 0f,
+    isPlaying: Boolean = false,
     onStartChange: (start: Float, end: Float, duration: Float) -> Unit,
+    /** 특정 지점부터 재생 요청(트랙 탭 / 좌핸들 탭) */
+    onSeek: (sec: Float) -> Unit = {},
+    /** 2초 루프 구간 변경. null 이면 루프 해제 */
+    onLoopChange: (loopStart: Float?, loopEnd: Float?) -> Unit = { _, _ -> },
     onHandleAdjusted: ((handleSide: String) -> Unit)? = null
 ) {
-    val scrollState = rememberScrollState()
     val density = LocalDensity.current
-
-    val barWidth = 8.dp
-    val gap = 8.dp
-    val barWidthPx = with(density) { barWidth.toPx() }
-    val gapPx = with(density) { gap.toPx() }
-
-    val basePxPerSecond = barWidthPx + gapPx
-    var pxPerSecond by remember { mutableStateOf(basePxPerSecond) }
-
-    val timelineWidthPx = (totalDuration + 5f) * pxPerSecond
-    val timelineWidthDp = with(density) { timelineWidthPx.toDp() }
+    val scope = rememberCoroutineScope()
 
     val minDurationSec = 10f
-    val maxDurationSec = 30f.coerceAtMost(totalDuration.toFloat())
+    val maxDurationSec = 30f.coerceAtMost(totalDuration.toFloat().coerceAtLeast(minDurationSec))
 
-    val barHeights = remember(totalDuration) {
-        (0 until totalDuration).map { (20..50).random().dp }
-    }
+    // 뷰포트에 보이는 시간 폭(초). 최대 구간(30s) + 여백이 항상 들어오도록.
+    val visibleSeconds = 40f
 
-    var parentWidthPx by remember { mutableStateOf(0f) }
+    // ---- 치수 (개선안 픽셀 기준, dp 변환) ----
+    val trackHeight = 120.dp
+    val boxHeight = 92.dp
+    val handleWidth = 22.dp
+    val handleHeight = 92.dp
+    val handleCorner = 7.dp
+    val boxCorner = 12.dp
+    val edgeButtonSize = 34.dp
 
-    var leftHandleX by remember { mutableStateOf(0f) }
-    var rightHandleX by remember { mutableStateOf(0f) }
-    var handlesInitialized by remember { mutableStateOf(false) }
+    val barWidth = 3.dp
+    val barGap = 4.dp
+    val barWidthPx = with(density) { barWidth.toPx() }
+    val barGapPx = with(density) { barGap.toPx() }
+    val handleWidthPx = with(density) { handleWidth.toPx() }
+
+    // ---- 상태 ----
+    var viewportWidthPx by remember { mutableStateOf(0f) }
+    var pxPerSec by remember { mutableStateOf(1f) }
+
+    var startSec by remember { mutableStateOf(initialStartSec) }
+    var endSec by remember { mutableStateOf(initialStartSec + initialDurationSec) }
+    val viewCenterSec = remember { Animatable(initialStartSec + initialDurationSec / 2f) }
+
+    var pressedSide by remember { mutableStateOf<HandleSide?>(null) }
+    var loopSide by remember { mutableStateOf<HandleSide?>(null) }
+    var initialized by remember { mutableStateOf(false) }
+
     var lastCommittedStart by remember { mutableStateOf(Float.NaN) }
     var lastCommittedEnd by remember { mutableStateOf(Float.NaN) }
-    var lastCommittedDuration by remember { mutableStateOf(Float.NaN) }
 
-    LaunchedEffect(parentWidthPx) {
-        if (parentWidthPx > 0f && !handlesInitialized) {
-            val maxDurationSecForScaling =
-                39f + ((totalDuration - 200).coerceAtLeast(0) / 50f) * 2f
-            val maxAllowedPxPerSecond = parentWidthPx / maxDurationSecForScaling
-
-            pxPerSecond = maxAllowedPxPerSecond
-            val initDur = initialDurationSec.coerceIn(minDurationSec, maxDurationSec)
-            val durationPx = initDur * pxPerSecond
-            val center = parentWidthPx / 2f
-
-            leftHandleX = center - durationPx / 2f
-            rightHandleX = center + durationPx / 2f
-
-            val maxStart = (totalDuration.toFloat() - initDur).coerceAtLeast(0f)
-            val targetStart = initialStartSec.coerceIn(0f, maxStart)
-            val targetScrollPx = (targetStart * pxPerSecond - leftHandleX).coerceAtLeast(0f)
-            kotlinx.coroutines.delay(48)
-            val maxScroll = scrollState.maxValue.coerceAtLeast(0)
-            scrollState.scrollTo(
-                targetScrollPx.roundToInt().coerceIn(0, maxScroll)
-            )
-
-            val sx = scrollState.value.toFloat()
-            val s = ((sx + leftHandleX) / pxPerSecond).coerceIn(0f, totalDuration.toFloat())
-            val e = ((sx + rightHandleX) / pxPerSecond).coerceIn(0f, totalDuration.toFloat())
-            val d = (e - s).coerceAtLeast(0f)
-            onStartChange(s, e, d)
-            lastCommittedStart = s
-            lastCommittedEnd = e
-            lastCommittedDuration = d
-
-            handlesInitialized = true
-        }
-    }
-
-    val scrollX = scrollState.value.toFloat()
-
-    val startTime =
-        ((scrollX + leftHandleX) / pxPerSecond).coerceIn(0f, totalDuration.toFloat())
-    val endTime =
-        ((scrollX + rightHandleX) / pxPerSecond).coerceIn(0f, totalDuration.toFloat())
-    val durationSec = (endTime - startTime).coerceAtLeast(0f)
-    var miniMapWidthPx by remember { mutableStateOf(0f) }
-    var wasScrolling by remember { mutableStateOf(false) }
     val latestOnHandleAdjusted by rememberUpdatedState(onHandleAdjusted)
+    val latestOnLoopChange by rememberUpdatedState(onLoopChange)
+    val latestOnSeek by rememberUpdatedState(onSeek)
 
-    fun currentSelection(): Triple<Float, Float, Float> {
-        val sx = scrollState.value.toFloat()
-        val s = ((sx + leftHandleX) / pxPerSecond).coerceIn(0f, totalDuration.toFloat())
-        val e = ((sx + rightHandleX) / pxPerSecond).coerceIn(0f, totalDuration.toFloat())
-        val d = (e - s).coerceAtLeast(0f)
-        return Triple(s, e, d)
-    }
+    fun secToX(sec: Float): Float = viewportWidthPx / 2f + (sec - viewCenterSec.value) * pxPerSec
+    fun xToSec(x: Float): Float = viewCenterSec.value + (x - viewportWidthPx / 2f) / pxPerSec
 
-    fun commitSelectionIfNeeded() {
-        val (s, e, d) = currentSelection()
-        val changed =
-            s != lastCommittedStart ||
-                e != lastCommittedEnd ||
-                d != lastCommittedDuration
-
-        if (changed) {
-            onStartChange(s, e, d)
-            lastCommittedStart = s
-            lastCommittedEnd = e
-            lastCommittedDuration = d
+    fun commit(force: Boolean = false) {
+        val d = (endSec - startSec).coerceAtLeast(0f)
+        if (force || startSec != lastCommittedStart || endSec != lastCommittedEnd) {
+            onStartChange(startSec, endSec, d)
+            lastCommittedStart = startSec
+            lastCommittedEnd = endSec
         }
     }
 
-    fun endHandleDrag(handleSide: String) {
-        val beforeStart = lastCommittedStart
-        val beforeEnd = lastCommittedEnd
-        val beforeDuration = lastCommittedDuration
-        commitSelectionIfNeeded()
-        val changed =
-            beforeStart != lastCommittedStart ||
-                beforeEnd != lastCommittedEnd ||
-                beforeDuration != lastCommittedDuration
-        if (changed) {
-            latestOnHandleAdjusted?.invoke(handleSide)
+    fun recenter(animated: Boolean = true) {
+        val target = (startSec + endSec) / 2f
+        scope.launch {
+            if (animated) {
+                viewCenterSec.animateTo(target, tween(durationMillis = 400, easing = LinearEasing))
+            } else {
+                viewCenterSec.snapTo(target)
+            }
         }
     }
 
-    Column(
-        modifier = Modifier.fillMaxWidth()
-    ) {
+    // 최초 초기화
+    LaunchedEffect(viewportWidthPx, totalDuration) {
+        if (viewportWidthPx > 0f && !initialized) {
+            pxPerSec = viewportWidthPx / visibleSeconds
+
+            val initDur = initialDurationSec.coerceIn(minDurationSec, maxDurationSec)
+            val maxStart = (totalDuration.toFloat() - initDur).coerceAtLeast(0f)
+            startSec = initialStartSec.coerceIn(0f, maxStart)
+            endSec = (startSec + initDur).coerceAtMost(totalDuration.toFloat())
+            viewCenterSec.snapTo((startSec + endSec) / 2f)
+
+            commit(force = true)
+            initialized = true
+        }
+    }
+
+    // 재생 인디케이터 스무딩 (onCurrentSecond 는 대략 1초 간격 → 선형 보간, seek/loop 점프는 snap)
+    val playAnim = remember { Animatable(0f) }
+    LaunchedEffect(currentPlaySec) {
+        if (abs(currentPlaySec - playAnim.value) > 1.2f) {
+            playAnim.snapTo(currentPlaySec)
+        } else {
+            playAnim.animateTo(currentPlaySec, tween(durationMillis = 1000, easing = LinearEasing))
+        }
+    }
+    val displayPlaySec = playAnim.value
+
+    fun applyResize(side: HandleSide, dxPx: Float) {
+        val dSec = dxPx / pxPerSec
+        when (side) {
+            HandleSide.LEFT -> {
+                startSec = (startSec + dSec).coerceIn(
+                    (endSec - maxDurationSec).coerceAtLeast(0f),
+                    endSec - minDurationSec
+                )
+            }
+            HandleSide.RIGHT -> {
+                endSec = (endSec + dSec).coerceIn(
+                    startSec + minDurationSec,
+                    (startSec + maxDurationSec).coerceAtMost(totalDuration.toFloat())
+                )
+            }
+        }
+        commit()
+    }
+
+    fun activateLoop(side: HandleSide) {
+        loopSide = side
+        val (ls, le) = when (side) {
+            HandleSide.LEFT -> startSec to (startSec + 2f).coerceAtMost(endSec)
+            HandleSide.RIGHT -> (endSec - 2f).coerceAtLeast(startSec) to endSec
+        }
+        latestOnLoopChange(ls, le)
+    }
+
+    fun deactivateLoop() {
+        if (loopSide != null) {
+            loopSide = null
+            latestOnLoopChange(null, null)
+        }
+    }
+
+    fun extendFront() {
+        val newStart = (startSec - 1f)
+            .coerceAtLeast(0f)
+            .coerceAtLeast(endSec - maxDurationSec)
+        if (newStart != startSec) {
+            startSec = newStart
+            commit()
+            recenter()
+        }
+    }
+
+    fun extendBack() {
+        val newEnd = (endSec + 1f)
+            .coerceAtMost(totalDuration.toFloat())
+            .coerceAtMost(startSec + maxDurationSec)
+        if (newEnd != endSec) {
+            endSec = newEnd
+            commit()
+            recenter()
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+
+        // ===== 메인 트랙 =====
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(120.dp)
+                .height(trackHeight)
                 .onGloballyPositioned {
-                    parentWidthPx = it.size.width.toFloat()
+                    val w = it.size.width.toFloat()
+                    if (w > 0f && w != viewportWidthPx) {
+                        viewportWidthPx = w
+                        if (initialized) pxPerSec = w / visibleSeconds
+                    }
+                }
+                // 트랙 탭 → 그 지점부터 재생
+                .pointerInput(Unit) {
+                    detectTapGestures { pos ->
+                        val sec = xToSec(pos.x)
+                        if (sec in startSec..endSec) {
+                            latestOnSeek(sec)
+                        }
+                    }
                 }
         ) {
-            Row(
-                modifier = Modifier
-                    .width(timelineWidthDp)
-                    .fillMaxHeight()
-                    .horizontalScroll(scrollState)
-            ) {
-                Canvas(
-                    modifier = Modifier
-                        .width(timelineWidthDp)
-                        .fillMaxHeight()
-                ) {
-                    val absScrollX = scrollState.value.toFloat()
+            // ---- 파형 / 박스 / 인디케이터 캔버스 ----
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                val w = size.width
+                val h = size.height
+                val centerY = h / 2f
+                if (pxPerSec <= 0f) return@Canvas
 
-                    val currentStartSec = (absScrollX + leftHandleX) / pxPerSecond
-                    val currentEndSec = (absScrollX + rightHandleX) / pxPerSecond
+                fun sx(sec: Float) = w / 2f + (sec - viewCenterSec.value) * pxPerSec
 
-                    for (i in 0 until totalDuration) {
-                        val barAbsX = i * (pxPerSecond + gapPx)
-                        val barVisibleX = barAbsX - absScrollX
+                val stepSec = (barWidthPx + barGapPx) / pxPerSec
+                val eps = 0.001f
+                val loopStartSec = when (loopSide) {
+                    HandleSide.LEFT -> startSec
+                    HandleSide.RIGHT -> (endSec - 2f).coerceAtLeast(startSec)
+                    null -> Float.NaN
+                }
+                val loopEndSec = when (loopSide) {
+                    HandleSide.LEFT -> (startSec + 2f).coerceAtMost(endSec)
+                    HandleSide.RIGHT -> endSec
+                    null -> Float.NaN
+                }
 
-                        if (barVisibleX + barWidthPx < 0 || barVisibleX > size.width) continue
+                var i = 0
+                var sec = 0f
+                while (sec <= totalDuration.toFloat()) {
+                    val x = sx(sec)
+                    if (x >= -barWidthPx && x <= w + barWidthPx) {
+                        val noise = abs(sin(i * 2.3f) + sin(i * 0.7f) * 0.5f) / 1.5f
+                        val barH = with(density) { (18.dp.toPx()) } + noise * with(density) { 46.dp.toPx() }
+                        val top = centerY - barH / 2f
 
-                        val barHeightPx = barHeights[i].toPx()
-                        val top = (size.height - barHeightPx) / 2f
-
-                        val barCenterSec =
-                            ((barAbsX - absScrollX) + barWidthPx / 2f) / pxPerSecond
-
-                        val inSelection = barCenterSec - 1f in currentStartSec + 1..currentEndSec
-
-                        val color = if (inSelection) Color.White else Color(0xFF454545)
-
+                        val inSection = sec >= startSec - eps && sec <= endSec + eps
+                        val played = isPlaying && sec <= displayPlaySec + eps
+                        val color = when {
+                            !inSection -> Color(0xFF454545)
+                            played -> mainGreen
+                            else -> Color.White
+                        }
                         drawRoundRect(
                             color = color,
-                            topLeft = Offset(barVisibleX, top),
-                            size = Size(barWidthPx, barHeightPx),
-                            cornerRadius = CornerRadius(12f, 12f)
+                            topLeft = Offset(x - barWidthPx / 2f, top),
+                            size = Size(barWidthPx, barH),
+                            cornerRadius = CornerRadius(barWidthPx, barWidthPx)
                         )
                     }
-                }
-            }
-
-            val handleYOffsetPx = with(density) { 20.dp.toPx().roundToInt() }
-
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .offset { IntOffset(leftHandleX.roundToInt(), handleYOffsetPx) }
-                    .pointerInput(Unit) {
-                        detectDragGestures(
-                            onDragEnd = { endHandleDrag("left") },
-                            onDragCancel = { endHandleDrag("left") }
-                        ) { change, drag ->
-                            change.consume()
-
-                            val parent = parentWidthPx
-                            if (parent <= 0f) return@detectDragGestures
-
-                            val candidateX = (leftHandleX + drag.x)
-                                .coerceIn(0f, rightHandleX)
-
-                            val candidateDurationSec =
-                                (rightHandleX - candidateX) / pxPerSecond
-
-                            if (candidateDurationSec in minDurationSec..maxDurationSec) {
-                                leftHandleX = candidateX
-                            }
-                        }
-                    }
-                    .zIndex(10f)
-            ) {
-                Box(
-                    modifier = Modifier
-                        .width(20.dp)
-                        .height(70.dp)
-                        .background(
-                            mainGreen,
-                            RoundedCornerShape(topStart = 4.dp, bottomStart = 4.dp)
-                        )
-                        .border(
-                            2.dp,
-                            mainGreen,
-                            RoundedCornerShape(topStart = 4.dp, bottomStart = 4.dp)
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Image(
-                        painter = painterResource(id = R.drawable.move),
-                        contentDescription = "left",
-                        modifier = Modifier
-                            .size(7.dp, 13.dp)
-                            .rotate(180f)
-                    )
+                    i++
+                    sec += stepSec
                 }
 
-                Spacer(modifier = Modifier.height(18.dp))
-
-                Text(
-                    text = formatTime(startTime),
-                    fontFamily = PaperlogyFontFamily,
-                    fontWeight = FontWeight.W400,
-                    fontSize = 14.sp,
-                    color = Color.White
-                )
-            }
-
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .offset { IntOffset(rightHandleX.roundToInt(), handleYOffsetPx) }
-                    .pointerInput(Unit) {
-                        detectDragGestures(
-                            onDragEnd = { endHandleDrag("right") },
-                            onDragCancel = { endHandleDrag("right") }
-                        ) { change, drag ->
-                            change.consume()
-
-                            val parent = parentWidthPx
-                            if (parent <= 0f) return@detectDragGestures
-
-                            val handleWidthPx = with(density) { 40.dp.toPx() }
-
-                            val candidateX = (rightHandleX + drag.x)
-                                .coerceIn(leftHandleX, parent - handleWidthPx)
-
-                            val candidateDurationSec =
-                                (candidateX - leftHandleX) / pxPerSecond
-
-                            if (candidateDurationSec in minDurationSec..maxDurationSec) {
-                                rightHandleX = candidateX
-                            }
-                        }
-                    }
-                    .zIndex(10f)
-            ) {
-                Box(
-                    modifier = Modifier
-                        .width(20.dp)
-                        .height(70.dp)
-                        .background(
-                            mainGreen,
-                            RoundedCornerShape(topEnd = 4.dp, bottomEnd = 4.dp)
-                        )
-                        .border(
-                            2.dp,
-                            mainGreen,
-                            RoundedCornerShape(topEnd = 4.dp, bottomEnd = 4.dp)
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Image(
-                        painter = painterResource(id = R.drawable.move),
-                        contentDescription = "right",
-                        modifier = Modifier.size(7.dp, 13.dp)
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(18.dp))
-
-                Text(
-                    text = formatTime(endTime),
-                    fontFamily = PaperlogyFontFamily,
-                    fontWeight = FontWeight.W400,
-                    fontSize = 14.sp,
-                    color = Color.White
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(20.dp))
-
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(50.dp)
-                .background(Color(0xFF1F1F1F), RoundedCornerShape(24.dp))
-                .border(1.dp, Color(0xFF666666), RoundedCornerShape(24.dp))
-                .padding(horizontal = 12.dp, vertical = 10.dp)
-                .onSizeChanged { miniMapWidthPx = it.width.toFloat() }
-        ) {
-            Canvas(
-                modifier = Modifier.fillMaxSize()
-            ) {
-                if (totalDuration <= 0) return@Canvas
-                val unitWidth = size.width / totalDuration.toFloat()
-                val barSpace = unitWidth * 0.35f
-                val miniBarWidth = (unitWidth - barSpace).coerceAtLeast(1f)
-
-                for (i in 0 until totalDuration) {
-                    val x = i * unitWidth
-                    // 화살표처럼 보이지 않게 사인파 기반으로 높이를 부드럽게 변화
-                    val phase = (i.toFloat() / totalDuration.toFloat()) * (PI.toFloat() * 10f)
-                    val wave = ((sin(phase.toDouble()).toFloat() + 1f) / 2f)
-                    val h = size.height * (0.32f + wave * 0.60f)
-                    val top = (size.height - h) / 2f
+                // 루프 2초 밴드 하이라이트
+                if (loopSide != null) {
+                    val lx = sx(loopStartSec)
+                    val rx = sx(loopEndSec)
+                    val bH = with(density) { boxHeight.toPx() }
                     drawRoundRect(
-                        color = Color(0xFFEDEDED),
-                        topLeft = Offset(x, top),
-                        size = Size(miniBarWidth, h),
-                        cornerRadius = CornerRadius(6f, 6f)
+                        color = mainGreen.copy(alpha = 0.28f),
+                        topLeft = Offset(lx, centerY - bH / 2f),
+                        size = Size((rx - lx).coerceAtLeast(0f), bH),
+                        cornerRadius = CornerRadius(
+                            with(density) { 6.dp.toPx() },
+                            with(density) { 6.dp.toPx() }
+                        )
+                    )
+                }
+
+                // 선택 구간 네온 박스 테두리
+                val boxLeft = sx(startSec)
+                val boxRight = sx(endSec)
+                val bH = with(density) { boxHeight.toPx() }
+                val strokePx = with(density) { 2.dp.toPx() }
+                val rad = with(density) { boxCorner.toPx() }
+                drawRoundRect(
+                    color = mainGreen,
+                    topLeft = Offset(boxLeft, centerY - bH / 2f),
+                    size = Size((boxRight - boxLeft).coerceAtLeast(0f), bH),
+                    cornerRadius = CornerRadius(rad, rad),
+                    style = Stroke(width = strokePx)
+                )
+
+                // 흰색 재생 인디케이터
+                if (isPlaying && displayPlaySec in startSec..endSec) {
+                    val px = sx(displayPlaySec)
+                    drawRoundRect(
+                        color = Color.White,
+                        topLeft = Offset(px - strokePx / 2f, centerY - bH / 2f),
+                        size = Size(strokePx, bH),
+                        cornerRadius = CornerRadius(strokePx, strokePx)
                     )
                 }
             }
 
-            val safeTotalDuration = totalDuration.coerceAtLeast(1).toFloat()
-            val selectionLeftRatio = (startTime / safeTotalDuration).coerceIn(0f, 1f)
-            val selectionWidthRatio =
-                (durationSec / safeTotalDuration).coerceIn(0f, 1f - selectionLeftRatio)
-            val selectionLeftPx = miniMapWidthPx * selectionLeftRatio
-            val selectionWidthPx = miniMapWidthPx * selectionWidthRatio
-            val latestSelectionLeftPx by rememberUpdatedState(selectionLeftPx)
-            val latestDurationSec by rememberUpdatedState(durationSec)
-            val latestSafeTotalDuration by rememberUpdatedState(safeTotalDuration)
-            var latestMiniMapTargetStartSec by remember { mutableStateOf(startTime) }
-            var latestMiniMapTargetDurationSec by remember { mutableStateOf(durationSec) }
-
-            Box(
+            // ---- 좌/우 핸들 (제스처) ----
+            HandleView(
+                side = HandleSide.LEFT,
+                width = handleWidth,
+                height = handleHeight,
+                corner = handleCorner,
+                pressed = pressedSide == HandleSide.LEFT,
                 modifier = Modifier
-                    .fillMaxHeight()
-                    .width(with(density) { selectionWidthPx.toDp() })
-                    .graphicsLayer {
-                        translationX = selectionLeftPx
+                    .offset {
+                        IntOffset(
+                            (secToX(startSec) - handleWidthPx / 2f).roundToInt(),
+                            0
+                        )
                     }
-                    .background(
-                        mainGreen.copy(alpha = 0.4f),
-                        RoundedCornerShape(8.dp)
-                    )
-                    .border(
-                        1.dp,
-                        mainGreen,
-                        RoundedCornerShape(8.dp)
-                    )
-                    .pointerInput(miniMapWidthPx, totalDuration, leftHandleX, pxPerSecond) {
-                        var dragStartSelectionLeftPx = 0f
-                        var dragAccumulatedPx = 0f
-                        var dragDurationSec = 0f
-                        detectDragGestures(
-                            onDragStart = {
-                                dragStartSelectionLeftPx = latestSelectionLeftPx
-                                dragAccumulatedPx = 0f
-                                dragDurationSec = latestDurationSec.coerceAtLeast(minDurationSec)
-                                    .coerceAtMost(maxDurationSec)
-                            },
-                            onDragEnd = {
-                                if (dragAccumulatedPx == 0f) return@detectDragGestures
-                                endHandleDrag("spectrum_bar")
-                            },
-                            onDragCancel = {
-                                if (dragAccumulatedPx != 0f) {
-                                    endHandleDrag("spectrum_bar")
-                                } else {
-                                    commitSelectionIfNeeded()
-                                }
-                            }
-                        ) { change, drag ->
-                            change.consume()
-                            dragAccumulatedPx += drag.x
-
-                            val maxStartSec =
-                                (totalDuration.toFloat() - dragDurationSec).coerceAtLeast(0f)
-                            val draggableRangePx =
-                                (miniMapWidthPx - (miniMapWidthPx * (dragDurationSec / latestSafeTotalDuration))).coerceAtLeast(1f)
-                            val targetSelectionLeftPx =
-                                (dragStartSelectionLeftPx + dragAccumulatedPx)
-                                    .coerceIn(0f, draggableRangePx)
-                            val targetStartSec =
-                                (targetSelectionLeftPx / draggableRangePx) * maxStartSec
-                            latestMiniMapTargetStartSec = targetStartSec
-                            latestMiniMapTargetDurationSec = dragDurationSec
-
-                            val targetScrollPx =
-                                ((targetStartSec * pxPerSecond) - leftHandleX)
-                                    .coerceIn(0f, scrollState.maxValue.toFloat())
-                            val delta = targetScrollPx - scrollState.value.toFloat()
-
-                            scrollState.dispatchRawDelta(delta)
+                    .align(Alignment.CenterStart)
+                    .zIndex(10f)
+                    .handleGesture(
+                        side = HandleSide.LEFT,
+                        onPressChange = { s, p -> pressedSide = if (p) s else null },
+                        onTap = { latestOnSeek(startSec) },
+                        onLoopStart = { activateLoop(it) },
+                        onLoopEnd = { deactivateLoop() },
+                        onDrag = { s, dx -> applyResize(s, dx) },
+                        onDragEnd = {
+                            commit(force = true)
+                            recenter()
+                            latestOnHandleAdjusted?.invoke(KillingPartHandle.LEFT)
                         }
-                    },
+                    )
+            )
+
+            HandleView(
+                side = HandleSide.RIGHT,
+                width = handleWidth,
+                height = handleHeight,
+                corner = handleCorner,
+                pressed = pressedSide == HandleSide.RIGHT,
+                modifier = Modifier
+                    .offset {
+                        IntOffset(
+                            (secToX(endSec) - handleWidthPx / 2f).roundToInt(),
+                            0
+                        )
+                    }
+                    .align(Alignment.CenterStart)
+                    .zIndex(10f)
+                    .handleGesture(
+                        side = HandleSide.RIGHT,
+                        onPressChange = { s, p -> pressedSide = if (p) s else null },
+                        onTap = { /* 우핸들 탭은 동작 없음 */ },
+                        onLoopStart = { activateLoop(it) },
+                        onLoopEnd = { deactivateLoop() },
+                        onDrag = { s, dx -> applyResize(s, dx) },
+                        onDragEnd = {
+                            commit(force = true)
+                            recenter()
+                            latestOnHandleAdjusted?.invoke(KillingPartHandle.RIGHT)
+                        }
+                    )
+            )
+
+            // ---- -1s / +1s 원형 버튼 ----
+            EdgeStepButton(
+                label = "-1s",
+                size = edgeButtonSize,
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .zIndex(11f),
+                onClick = { extendFront() }
+            )
+            EdgeStepButton(
+                label = "+1s",
+                size = edgeButtonSize,
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .zIndex(11f),
+                onClick = { extendBack() }
             )
         }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // ---- 핸들 시간 라벨 ----
+        Box(modifier = Modifier.fillMaxWidth().height(18.dp)) {
+            val labelHalfPx = with(density) { 38.dp.toPx() }
+            HandleTimeLabel(
+                text = formatTime(startSec),
+                modifier = Modifier.offset {
+                    IntOffset(
+                        (secToX(startSec) - labelHalfPx)
+                            .coerceIn(0f, (viewportWidthPx - labelHalfPx * 2f).coerceAtLeast(0f))
+                            .roundToInt(),
+                        0
+                    )
+                }
+            )
+            HandleTimeLabel(
+                text = formatTime(endSec),
+                modifier = Modifier.offset {
+                    IntOffset(
+                        (secToX(endSec) - labelHalfPx)
+                            .coerceIn(0f, (viewportWidthPx - labelHalfPx * 2f).coerceAtLeast(0f))
+                            .roundToInt(),
+                        0
+                    )
+                }
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // ===== 미니맵 =====
+        MiniMap(
+            totalDuration = totalDuration,
+            startSec = startSec,
+            endSec = endSec,
+            onScrub = { newStartSec ->
+                val dur = (endSec - startSec)
+                val ns = newStartSec.coerceIn(0f, (totalDuration - dur).coerceAtLeast(0f))
+                startSec = ns
+                endSec = ns + dur
+                commit()
+                recenter(animated = false)
+            },
+            onScrubEnd = {
+                commit(force = true)
+                latestOnHandleAdjusted?.invoke(KillingPartHandle.SPECTRUM_BAR)
+            }
+        )
 
         Spacer(modifier = Modifier.height(10.dp))
 
@@ -479,13 +495,12 @@ fun KillingPartSelector(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = "선택 구간: ${formatTime(startTime)} ~ ${formatTime(endTime)}",
+                text = "선택 구간: ${formatTime(startSec)} ~ ${formatTime(endSec)}",
                 fontFamily = PaperlogyFontFamily,
                 fontWeight = FontWeight.W500,
                 fontSize = 10.sp,
                 color = mainGreen
             )
-
             Text(
                 text = "최대 30초",
                 fontFamily = PaperlogyFontFamily,
@@ -495,20 +510,230 @@ fun KillingPartSelector(
             )
         }
     }
+}
 
-    LaunchedEffect(scrollState.isScrollInProgress) {
-        if (scrollState.isScrollInProgress) {
-            wasScrolling = true
-        } else if (wasScrolling) {
-            wasScrolling = false
-            commitSelectionIfNeeded()
-        }
+/** 핸들 시간 라벨 상수 (분석 이벤트 handle_side 값) */
+private object KillingPartHandle {
+    const val LEFT = "left"
+    const val RIGHT = "right"
+    const val SPECTRUM_BAR = "spectrum_bar"
+}
+
+@Composable
+private fun HandleView(
+    side: HandleSide,
+    width: androidx.compose.ui.unit.Dp,
+    height: androidx.compose.ui.unit.Dp,
+    corner: androidx.compose.ui.unit.Dp,
+    pressed: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val scale by animateFloatAsState(if (pressed) 1.16f else 1f, label = "handleScale")
+    Box(
+        modifier = modifier
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            }
+            .width(width)
+            .height(height)
+            .background(mainGreen, RoundedCornerShape(corner)),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = if (side == HandleSide.LEFT) Icons.Filled.KeyboardArrowLeft else Icons.Filled.KeyboardArrowRight,
+            contentDescription = if (side == HandleSide.LEFT) "left handle" else "right handle",
+            tint = Color(0xFF0A0A0A)
+        )
     }
+}
 
-    LaunchedEffect(handlesInitialized) {
-        if (handlesInitialized) {
-            commitSelectionIfNeeded()
+@Composable
+private fun HandleTimeLabel(text: String, modifier: Modifier = Modifier) {
+    Box(modifier = modifier.width(76.dp), contentAlignment = Alignment.Center) {
+        Text(
+            text = text,
+            fontFamily = PaperlogyFontFamily,
+            fontWeight = FontWeight.W400,
+            fontSize = 13.sp,
+            color = Color.White
+        )
+    }
+}
+
+@Composable
+private fun EdgeStepButton(
+    label: String,
+    size: androidx.compose.ui.unit.Dp,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(mainGreen)
+            .pointerInput(Unit) { detectTapGestures { onClick() } },
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = label,
+            fontFamily = PaperlogyFontFamily,
+            fontWeight = FontWeight.W700,
+            fontSize = 11.sp,
+            color = Color(0xFF0A0A0A)
+        )
+    }
+}
+
+@Composable
+private fun MiniMap(
+    totalDuration: Int,
+    startSec: Float,
+    endSec: Float,
+    onScrub: (newStartSec: Float) -> Unit,
+    onScrubEnd: () -> Unit
+) {
+    val density = LocalDensity.current
+    var widthPx by remember { mutableStateOf(0f) }
+    val latestStartSec by rememberUpdatedState(startSec)
+    val latestEndSec by rememberUpdatedState(endSec)
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(44.dp)
+            .background(Color(0xFF1F1F1F), RoundedCornerShape(22.dp))
+            .border(1.dp, Color(0xFF3A3A3A), RoundedCornerShape(22.dp))
+            .padding(horizontal = 12.dp, vertical = 9.dp)
+            .onSizeChanged { widthPx = it.width.toFloat() }
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            if (totalDuration <= 0) return@Canvas
+            val unitWidth = size.width / totalDuration.toFloat()
+            val barSpace = unitWidth * 0.4f
+            val miniBarWidth = (unitWidth - barSpace).coerceAtLeast(1f)
+            for (i in 0 until totalDuration) {
+                val x = i * unitWidth
+                val phase = (i.toFloat() / totalDuration.toFloat()) * (Math.PI.toFloat() * 10f)
+                val wave = (sin(phase.toDouble()).toFloat() + 1f) / 2f
+                val hh = size.height * (0.3f + wave * 0.6f)
+                val top = (size.height - hh) / 2f
+                drawRoundRect(
+                    color = Color(0xFF9A9A9A),
+                    topLeft = Offset(x, top),
+                    size = Size(miniBarWidth, hh),
+                    cornerRadius = CornerRadius(3f, 3f)
+                )
+            }
         }
+
+        val safeTotal = totalDuration.coerceAtLeast(1).toFloat()
+        val leftRatio = (startSec / safeTotal).coerceIn(0f, 1f)
+        val widthRatio = ((endSec - startSec) / safeTotal).coerceIn(0f, 1f - leftRatio)
+        val selLeftPx = widthPx * leftRatio
+        val selWidthPx = widthPx * widthRatio
+
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .width(with(density) { selWidthPx.toDp() })
+                .graphicsLayer { translationX = selLeftPx }
+                .background(mainGreen.copy(alpha = 0.4f), RoundedCornerShape(8.dp))
+                .border(1.dp, mainGreen, RoundedCornerShape(8.dp))
+                .pointerInput(widthPx, totalDuration) {
+                    var accStartSec = 0f
+                    detectDragGestures(
+                        onDragStart = { accStartSec = latestStartSec },
+                        onDragEnd = { onScrubEnd() },
+                        onDragCancel = { onScrubEnd() }
+                    ) { change, drag ->
+                        change.consume()
+                        if (widthPx <= 0f) return@detectDragGestures
+                        val dSec = (drag.x / widthPx) * safeTotal
+                        accStartSec += dSec
+                        onScrub(accStartSec)
+                    }
+                }
+        )
+    }
+}
+
+/**
+ * 핸들 제스처: 탭 / 드래그(리사이즈) / 0.5초 롱프레스(2초 루프)를 하나의 제스처로 판별.
+ *  - 0.5초 내 이동(slop 초과) → 드래그
+ *  - 0.5초 내 손 뗌 → 탭
+ *  - 0.5초 유지 → 루프 활성 (이후 이동 시 루프 해제 후 드래그)
+ */
+private fun Modifier.handleGesture(
+    side: HandleSide,
+    onPressChange: (HandleSide, Boolean) -> Unit,
+    onTap: (HandleSide) -> Unit,
+    onLoopStart: (HandleSide) -> Unit,
+    onLoopEnd: () -> Unit,
+    onDrag: (HandleSide, Float) -> Unit,
+    onDragEnd: () -> Unit
+): Modifier = this.pointerInput(side) {
+    val slop = viewConfiguration.touchSlop
+    awaitEachGesture {
+        val down = awaitFirstDown(requireUnconsumed = false)
+        onPressChange(side, true)
+        var dragging = false
+        var looping = false
+
+        fun changeFor(changes: List<PointerInputChange>): PointerInputChange =
+            changes.firstOrNull { it.id == down.id } ?: changes.first()
+
+        // 1단계: 0.5초 내 tap / drag / (timeout=long press) 판별
+        val decided: String? = withTimeoutOrNull(500L) {
+            var result = "tap"
+            while (true) {
+                val event = awaitPointerEvent()
+                val ch = changeFor(event.changes)
+                if (!ch.pressed) { result = "tap"; break }
+                if (abs(ch.position.x - down.position.x) > slop) { result = "drag"; break }
+            }
+            result
+        }
+
+        when (decided) {
+            null -> {
+                // 롱프레스 → 루프 활성
+                looping = true
+                onLoopStart(side)
+            }
+            "tap" -> {
+                onPressChange(side, false)
+                onTap(side)
+                return@awaitEachGesture
+            }
+            "drag" -> {
+                dragging = true
+            }
+        }
+
+        // 2단계: 이후 포인터 추적
+        while (true) {
+            val event = awaitPointerEvent()
+            val ch = changeFor(event.changes)
+            if (!ch.pressed) break
+            val dx = ch.positionChange().x
+            if (looping) {
+                // 루프 중 이동하면 루프 해제 후 드래그 전환
+                if (abs(ch.position.x - down.position.x) > slop) {
+                    looping = false
+                    onLoopEnd()
+                    dragging = true
+                    if (dx != 0f) { onDrag(side, dx); ch.consume() }
+                }
+            } else if (dragging) {
+                if (dx != 0f) { onDrag(side, dx); ch.consume() }
+            }
+        }
+
+        if (looping) onLoopEnd()
+        if (dragging) onDragEnd()
+        onPressChange(side, false)
     }
 }
 
@@ -517,6 +742,10 @@ fun KillingPartSelector(
 fun KillingPartSelectorPreview() {
     KillingPartSelector(
         totalDuration = 150,
+        initialStartSec = 90f,
+        initialDurationSec = 26f,
+        currentPlaySec = 100f,
+        isPlaying = true,
         onStartChange = { _, _, _ -> }
     )
 }

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/SelectDurationScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/SelectDurationScreen.kt
@@ -109,7 +109,12 @@ fun SelectDurationScreen(
     imageUrl: String,
     videoUrl: String = "",
     totalDuration: Int,
-    tutorialMode: Boolean = false
+    tutorialMode: Boolean = false,
+    // 장르 추천용 (iTunes) — write_diary 로 그대로 전달
+    sourceType: String = "ITUNES",
+    trackId: String? = null,
+    artistId: String? = null,
+    primaryGenreName: String? = null
 ) {
     var duration by remember { mutableStateOf(20f) }
     var start by remember { mutableStateOf(0f) }
@@ -195,6 +200,10 @@ fun SelectDurationScreen(
                     "&end=${end.toInt()}" +
                     "&videoUrl=$encodedVideoUrl" +
                     "&totalDuration=${currentTotalDuration}" +
+                    "&sourceType=$sourceType" +
+                    "&trackId=${trackId ?: ""}" +
+                    "&artistId=${artistId ?: ""}" +
+                    "&primaryGenreName=${Uri.encode(primaryGenreName ?: "")}" +
                     "&tutorial=$tutorialArg"
         )
     }

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/SelectDurationScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/SelectDurationScreen.kt
@@ -50,6 +50,7 @@ import com.killingpart.killingpoint.data.model.YouTubeVideo
 import com.killingpart.killingpoint.R
 import com.killingpart.killingpoint.ui.screen.AddMusicScreen.korean_font_medium
 import com.killingpart.killingpoint.ui.screen.MainScreen.YouTubePlayerBox
+import com.killingpart.killingpoint.ui.screen.MainScreen.PlayCommand
 import com.killingpart.killingpoint.ui.screen.WriteDiaryScreen.AlbumDiaryBoxWithoutContent
 import com.killingpart.killingpoint.data.model.Diary
 import com.killingpart.killingpoint.data.model.Scope
@@ -127,6 +128,13 @@ fun SelectDurationScreen(
         val endValue = (startSeconds + durationSeconds)
         endValue
     }
+
+    // ---- 재생 연동 상태 (구간자르기 개선안) ----
+    var currentPlaySec by remember { mutableStateOf(0f) }
+    var playerPlaying by remember { mutableStateOf(false) }
+    var seekCommand by remember { mutableStateOf<PlayCommand?>(null) }
+    var seekIdCounter by remember { mutableStateOf(0L) }
+    var loopOverride by remember { mutableStateOf<ClosedFloatingPointRange<Float>?>(null) }
 
     var currentVideoUrl by remember { mutableStateOf<String?>(if (videoUrl.isNotEmpty()) videoUrl else null) }
     var currentTotalDuration by remember { mutableStateOf(if (totalDuration > 0) totalDuration else 10) }
@@ -325,7 +333,18 @@ fun SelectDurationScreen(
                             .size(250.dp, 150.dp)
                     ) {
 
-                        YouTubePlayerBox(tempDiary, startSeconds, durationSeconds, shouldLoop = true)
+                        YouTubePlayerBox(
+                            tempDiary,
+                            startSeconds,
+                            durationSeconds,
+                            shouldLoop = true,
+                            onCurrentSecondChange = { currentPlaySec = it },
+                            onPlayingChange = { playerPlaying = it },
+                            playCommand = seekCommand,
+                            loopOverride = loopOverride,
+                            // 구간 리사이즈/±1초 조정 중 재생을 처음으로 되돌리지 않음
+                            seekOnStartChange = false
+                        )
                     }
                 }
                 Spacer(modifier = Modifier.height(12.dp))
@@ -362,10 +381,19 @@ fun SelectDurationScreen(
                             totalDuration = currentTotalDuration,
                             initialStartSec = start,
                             initialDurationSec = duration,
+                            currentPlaySec = currentPlaySec,
+                            isPlaying = playerPlaying,
                             onStartChange = { s, e, d ->
                                 start = s
                                 end = e
                                 duration = d
+                            },
+                            onSeek = { sec ->
+                                seekIdCounter += 1
+                                seekCommand = PlayCommand(seekIdCounter, sec)
+                            },
+                            onLoopChange = { ls, le ->
+                                loopOverride = if (ls != null && le != null) ls..le else null
                             },
                             onHandleAdjusted = { handleSide ->
                                 KillingPartCutAnalytics.cutHandleAdjusted(handleSide)

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/SelectDurationScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/SelectDurationScreen.kt
@@ -111,7 +111,7 @@ fun SelectDurationScreen(
     totalDuration: Int,
     tutorialMode: Boolean = false
 ) {
-    var duration by remember { mutableStateOf(10f) }
+    var duration by remember { mutableStateOf(20f) }
     var start by remember { mutableStateOf(0f) }
 
     val startSeconds = remember(start) {

--- a/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/WriteDiaryScreen.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/screen/WriteDiaryScreen/WriteDiaryScreen.kt
@@ -37,6 +37,7 @@ import androidx.navigation.compose.rememberNavController
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.killingpart.killingpoint.data.model.CreateDiaryRequest
+import com.killingpart.killingpoint.data.model.MusicMetadata
 import com.killingpart.killingpoint.data.repository.AuthRepository
 import com.killingpart.killingpoint.data.spotify.SimpleTrack
 import com.killingpart.killingpoint.R
@@ -71,7 +72,12 @@ fun WriteDiaryScreen(
     end: String,
     videoUrl: String,
     totalDuration: Int = 0, // YouTube 비디오 전체 길이 (초 단위)
-    tutorialMode: Boolean = false
+    tutorialMode: Boolean = false,
+    // 장르 추천용 (iTunes) — 등록 요청에 포함
+    sourceType: String = "ITUNES",
+    trackId: String? = null,
+    artistId: String? = null,
+    primaryGenreName: String? = null
 ) {
     val coroutineScope = rememberCoroutineScope()
     var content by remember { mutableStateOf("") }
@@ -316,7 +322,13 @@ fun WriteDiaryScreen(
                                 duration = duration,
                                 start = start,
                                 end = end,
-                                totalDuration = totalDuration
+                                totalDuration = totalDuration,
+                                musicMetadata = MusicMetadata(
+                                    sourceType = sourceType,
+                                    trackId = trackId,
+                                    artistId = artistId,
+                                    primaryGenreName = primaryGenreName
+                                )
                             )
                             repo.createDiary(body)
                         }.onSuccess {

--- a/app/src/main/java/com/killingpart/killingpoint/ui/viewmodel/SpotifyViewModel.kt
+++ b/app/src/main/java/com/killingpart/killingpoint/ui/viewmodel/SpotifyViewModel.kt
@@ -2,7 +2,7 @@ package com.killingpart.killingpoint.ui.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.killingpart.killingpoint.data.repository.SpotifyRepository
+import com.killingpart.killingpoint.data.repository.ItunesRepository
 import com.killingpart.killingpoint.data.spotify.SimpleTrack
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,7 +16,8 @@ sealed interface SpotifyUiState {
 }
 
 class SpotifyViewModel(
-    private val repo: SpotifyRepository = SpotifyRepository.create()
+    // 곡 검색 소스: Spotify → Apple iTunes Search API 로 교체
+    private val repo: ItunesRepository = ItunesRepository.create()
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<SpotifyUiState>(SpotifyUiState.Idle)


### PR DESCRIPTION
### 변경사항
- 기존 구간자르기(핸들고정+스크롤) -> 박스컨테이너 및 애니메이터로 모델 전환
- 재생 상태 공유를 위한 youtubePlayerBox 파라미터 추가 
- -1s/+1s 버튼 추가 및 중앙점 자동 조정 로직 추가
- 2초 구간 반복 투명 구간 및 재생 루프 추가
- 재생 인디케이터 높이 -> 박스 컨테이너에 맞춰 동적 조정
- 아이튠즈 api 및 장르 관련 4필드 추가 (spotify 유지) 

<img height="600" alt="1000000103" src="https://github.com/user-attachments/assets/1461cb48-66a3-4f84-89bf-b466dfdff296" />
